### PR TITLE
경북대 BE_조현준 1단계 엔티티 매핑 구현

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,45 @@
 # spring-gift-enhancement
+
+## 🎁 주요 구현 내용
+1. 데이터 접근 계층 리팩터링 (JdbcTemplate → Spring Data JPA)
+기존 JdbcTemplate 기반의 데이터 중심 설계를, 객체지향적인 설계를 지향하는 Spring Data JPA 방식으로 전면 리팩터링했다.
+
+Repository 인터페이스: ProductRepository, MemberRepository, WishRepository를 JpaRepository를 상속받는 인터페이스로 전환하여, 반복적인 CRUD 코드를 제거하고 코드의 가독성과 유지보수성을 크게 향상시켰다.
+
+2. 객체지향적 엔티티 설계 및 연관관계 매핑
+객체 참조 설계: 테이블의 외래 키(FK)를 필드로 갖던 방식에서 벗어나, 엔티티 간에 직접 객체 참조(@ManyToOne, @OneToMany)를 사용하도록 설계를 개선했다. 이를 통해 서비스 계층은 ID가 아닌 객체 중심으로 로직을 처리할 수 있게 되었다.
+
+양방향 연관관계: Member와 Wish 사이에 양방향 연관관계를 설정하여, member.getWishes()와 같이 객체 그래프 탐색을 통해 연관된 데이터를 쉽게 조회할 수 있도록 구현했다.
+
+3. 서비스 계층 고도화
+   
+트랜잭션 최적화: 모든 서비스 클래스에 @Transactional(readOnly = true)를 기본으로 적용하고, 데이터 변경이 필요한 CUD(Create, Update, Delete) 메서드에만 @Transactional을 개별적으로 적용하여 읽기/쓰기 트랜잭션을 명확히 분리하고 조회 성능을 최적화했다.
+
+4. 테스트 전략 수립 및 강화
+계층별 테스트 분리: 테스트의 목적에 따라 아래와 같이 전략을 분리했다.
+
+Repository 테스트 (@DataJpaTest): JPA 관련 설정만 로드하여 엔티티 매핑과 연관관계의 정확성을 검증하는 학습 테스트를 추가했다.
+
+Service 테스트 (@SpringBootTest): 실제 DB 연동을 포함한 통합 테스트 환경에서 트랜잭션과 더티 체킹 등 핵심 비즈니스 로직을 검증했다.
+
+테스트 환경 분리: application-test.properties를 도입하여, 실제 실행 환경과 테스트 환경의 데이터베이스 및 JPA 설정을 완벽하게 분리함으로써 테스트의 독립성과 안정성을 확보했다.
+
+## 📂 프로젝트 구조
+JPA 리팩터링 이후에도 패키지 구조는 역할과 책임에 따라 명확하게 유지된다. 다만, repository 패키지 내부의 구현체가 클래스에서 인터페이스로 변경되었다.
+
+└── src
+├── main
+│   └── java
+│       └── gift
+│           ├── ...
+│           ├── entity       // @Entity, @Id, @OneToMany 등 JPA 어노테이션으로 매핑
+│           ├── repository   // JpaRepository를 상속받는 인터페이스
+│           └── service      // @Transactional, 더티 체킹을 활용한 비즈니스 로직
+│
+└── test
+├── java
+│   └── gift
+│       ├── repository   // @DataJpaTest를 사용한 레포지토리 테스트
+│       └── service      // @SpringBootTest를 사용한 서비스 통합 테스트
+└── resources
+└── application-test.properties // 테스트 전용 설정 파일

--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-jdbc'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'

--- a/src/main/java/gift/config/WebConfig.java
+++ b/src/main/java/gift/config/WebConfig.java
@@ -1,11 +1,11 @@
 package gift.config;
 
 import gift.interceptor.LoginInterceptor;
+import gift.resolver.LoginMemberArgumentResolver;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
-import gift.resolver.LoginMemberArgumentResolver;
 
 import java.util.List;
 
@@ -14,9 +14,10 @@ public class WebConfig implements WebMvcConfigurer {
 
     private final LoginInterceptor loginInterceptor;
     private final LoginMemberArgumentResolver loginMemberArgumentResolver;
+
     public WebConfig(LoginInterceptor loginInterceptor, LoginMemberArgumentResolver loginMemberArgumentResolver) {
         this.loginInterceptor = loginInterceptor;
-        this.loginMemberArgumentResolver=loginMemberArgumentResolver;
+        this.loginMemberArgumentResolver = loginMemberArgumentResolver;
     }
 
     @Override
@@ -30,7 +31,7 @@ public class WebConfig implements WebMvcConfigurer {
     }
 
     @Override
-    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers){
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
         resolvers.add(loginMemberArgumentResolver);
     }
 }

--- a/src/main/java/gift/controller/api/ApiExceptionHandler.java
+++ b/src/main/java/gift/controller/api/ApiExceptionHandler.java
@@ -68,6 +68,7 @@ public class ApiExceptionHandler {
     public ErrorResponse handleWishAlreadyExists(WishAlreadyExistsException e) {
         return new ErrorResponse(e.getMessage());
     }
+
     @ExceptionHandler(UnauthorizedWishAccessException.class)
     @ResponseStatus(HttpStatus.FORBIDDEN)
     public ErrorResponse handleUnauthorizedWishAccess(UnauthorizedWishAccessException e) {

--- a/src/main/java/gift/controller/api/WishApiController.java
+++ b/src/main/java/gift/controller/api/WishApiController.java
@@ -18,6 +18,7 @@ import java.util.List;
 public class WishApiController {
 
     private final WishService wishService;
+
     public WishApiController(WishService wishService) {
         this.wishService = wishService;
     }
@@ -36,7 +37,7 @@ public class WishApiController {
     }
 
     @DeleteMapping("/{wishId}")
-    public ResponseEntity<Void> deleteWish( @PathVariable Long wishId, @LoginMember Member loginMember) {
+    public ResponseEntity<Void> deleteWish(@PathVariable Long wishId, @LoginMember Member loginMember) {
         wishService.deleteWish(wishId, loginMember);
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/gift/dto/LoginRequestDto.java
+++ b/src/main/java/gift/dto/LoginRequestDto.java
@@ -3,15 +3,19 @@ package gift.dto;
 public class LoginRequestDto {
     private String email;
     private String password;
+
     public String getEmail() {
         return email;
     }
+
     public void setEmail(String email) {
         this.email = email;
     }
+
     public String getPassword() {
         return password;
     }
+
     public void setPassword(String password) {
         this.password = password;
     }

--- a/src/main/java/gift/dto/RegisterRequestDto.java
+++ b/src/main/java/gift/dto/RegisterRequestDto.java
@@ -3,15 +3,19 @@ package gift.dto;
 public class RegisterRequestDto {
     private String email;
     private String password;
+
     public String getEmail() {
         return email;
     }
+
     public void setEmail(String email) {
         this.email = email;
     }
+
     public String getPassword() {
         return password;
     }
+
     public void setPassword(String password) {
         this.password = password;
     }

--- a/src/main/java/gift/dto/TokenResponse.java
+++ b/src/main/java/gift/dto/TokenResponse.java
@@ -2,9 +2,11 @@ package gift.dto;
 
 public class TokenResponse {
     private String token;
+
     public TokenResponse(String token) {
         this.token = token;
     }
+
     public String getToken() {
         return token;
     }

--- a/src/main/java/gift/dto/WishRequestDto.java
+++ b/src/main/java/gift/dto/WishRequestDto.java
@@ -2,9 +2,11 @@ package gift.dto;
 
 public class WishRequestDto {
     private Long productId;
+
     public Long getProductId() {
         return productId;
     }
+
     public void setProductId(Long productId) {
         this.productId = productId;
     }

--- a/src/main/java/gift/entity/Member.java
+++ b/src/main/java/gift/entity/Member.java
@@ -1,9 +1,25 @@
 package gift.entity;
 
-public class Member{
+import jakarta.persistence.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "member")
+public class Member {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @Column(nullable = false, unique = true)
     private String email;
+    @Column(nullable = false)
     private String password;
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Wish> wishes = new ArrayList<>();
+
 
     public Member(Long id, String email, String password) {
         this.id = id;
@@ -15,23 +31,38 @@ public class Member{
         this(null, email, password);
     }
 
+    public Member() {
+    }
+
     public Long getId() {
         return id;
     }
+
     public String getEmail() {
         return email;
     }
+
     public String getPassword() {
         return password;
+    }
+
+    public List<Wish> getWishes() {
+        return wishes;
     }
 
     public void setId(Long id) {
         this.id = id;
     }
+
     public void setEmail(String email) {
         this.email = email;
     }
+
     public void setPassword(String password) {
         this.password = password;
+    }
+
+    public void setWishes(List<Wish> wishes) {
+        this.wishes = wishes;
     }
 }

--- a/src/main/java/gift/entity/Product.java
+++ b/src/main/java/gift/entity/Product.java
@@ -1,10 +1,31 @@
 package gift.entity;
 
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "products")
 public class Product {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @Column(nullable = false, length = 15)
     private String name;
+    @Column(nullable = false)
     private int price;
+    @Column(name = "image_url", nullable = false)
     private String imageUrl;
+
+    public Product() {
+
+    }
+
+    public Product(String name, int price, String imageUrl) {
+        this.name = name;
+        this.price = price;
+        this.imageUrl = imageUrl;
+    }
 
     public Product(Long id, String name, int price, String imageUrl) {
         this.id = id;

--- a/src/main/java/gift/entity/Wish.java
+++ b/src/main/java/gift/entity/Wish.java
@@ -1,32 +1,55 @@
 package gift.entity;
 
-public class Wish {
-    private Long id;
-    private Long memberId;
-    private Long productId;
 
-    public Wish(Long id,Long memberId, Long productId){
-        this.id = id;
-        this.memberId = memberId;
-        this.productId = productId;
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "wish", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"member_id", "product_id"})
+})
+public class Wish {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "product_id", nullable = false)
+    private Product product;
+
+    public Wish() {
+
+    }
+
+    public Wish(Member member, Product product) {
+        this.member = member;
+        this.product = product;
     }
 
     public Long getId() {
         return id;
     }
+
     public void setId(Long id) {
-        this.id=id;
+        this.id = id;
     }
-    public Long getMemberId() {
-        return memberId;
+
+    public Member getMember() {
+        return member;
     }
-    public void setMemberId(Long memberId) {
-        this.memberId = memberId;
+
+    public void setMember(Long memberId) {
+        this.member = member;
     }
-    public Long getProductId() {
-        return productId;
+
+    public Product getProduct() {
+        return product;
     }
-    public void setProductId(Long productId) {
-        this.productId = productId;
+
+    public void setProduct(Long productId) {
+        this.product = product;
     }
 }
+

--- a/src/main/java/gift/interceptor/LoginInterceptor.java
+++ b/src/main/java/gift/interceptor/LoginInterceptor.java
@@ -28,7 +28,7 @@ public class LoginInterceptor implements HandlerInterceptor {
         String token = authHeader.substring(BEARER_PREFIX.length());
         try {
             jwtTokenProvider.validateToken(token);
-            Long memberId=jwtTokenProvider.getSubject(token);
+            Long memberId = jwtTokenProvider.getSubject(token);
             request.setAttribute("memberId", memberId);
             return true;
         } catch (JwtException | NumberFormatException e) {

--- a/src/main/java/gift/repository/MemberRepository.java
+++ b/src/main/java/gift/repository/MemberRepository.java
@@ -1,59 +1,12 @@
 package gift.repository;
 
 import gift.entity.Member;
-import org.springframework.dao.EmptyResultDataAccessException;
-import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.jdbc.core.RowMapper;
-import org.springframework.jdbc.core.simple.SimpleJdbcInsert;
+import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
-import java.util.HashMap;
-import java.util.Map;
+
 import java.util.Optional;
 
 @Repository
-public class MemberRepository {
-    private final JdbcTemplate jdbcTemplate;
-    private final SimpleJdbcInsert insert;
-
-    public MemberRepository(JdbcTemplate jdbcTemplate) {
-        this.jdbcTemplate = jdbcTemplate;
-        this.insert = new SimpleJdbcInsert(jdbcTemplate)
-                .withTableName("member")
-                .usingGeneratedKeyColumns("id");
-    }
-
-    public Member save(Member member) {
-
-        Map<String, Object>  map = new HashMap<>();
-        map.put("email", member.getEmail());
-        map.put("password", member.getPassword());
-        Number key= insert.executeAndReturnKey(map);
-        return new Member(key.longValue(), member.getEmail(), member.getPassword());
-    }
-
-    public Optional<Member> findByEmail(String email) {
-        String sql = "SELECT id, email, password FROM member WHERE email = ?";
-        try {
-            Member member = jdbcTemplate.queryForObject(sql, MEMBER_ROW_MAPPER, email);
-            return Optional.of(member);
-        } catch (EmptyResultDataAccessException e) {
-            return Optional.empty();
-        }
-    }
-
-    public Optional<Member> findById(Long id) {
-        String sql = "SELECT id, email, password FROM member WHERE id = ?";
-        try {
-            Member member = jdbcTemplate.queryForObject(sql, MEMBER_ROW_MAPPER, id);
-            return Optional.of(member);
-        } catch (EmptyResultDataAccessException e) {
-            return Optional.empty();
-        }
-    }
-
-    private static final RowMapper<Member> MEMBER_ROW_MAPPER = (rs, rowNum) -> new Member(
-            rs.getLong("id"),
-            rs.getString("email"),
-            rs.getString("password")
-    );
+public interface MemberRepository extends JpaRepository<Member, Long> {
+    Optional<Member> findByEmail(String email);
 }

--- a/src/main/java/gift/repository/ProductRepository.java
+++ b/src/main/java/gift/repository/ProductRepository.java
@@ -1,79 +1,10 @@
 package gift.repository;
 
 import gift.entity.Product;
-import gift.exception.ProductNotFoundException;
-import org.springframework.dao.EmptyResultDataAccessException;
-import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.jdbc.core.RowMapper;
-import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
-import org.springframework.jdbc.core.simple.SimpleJdbcInsert;
+import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-
 @Repository
-public class ProductRepository {
-    private final JdbcTemplate jdbcTemplate;
-    private final SimpleJdbcInsert insert;
+public interface ProductRepository extends JpaRepository<Product, Long> {
 
-    public ProductRepository(JdbcTemplate jdbcTemplate) {
-        this.jdbcTemplate = jdbcTemplate;
-        this.insert = new SimpleJdbcInsert(jdbcTemplate)
-                .usingGeneratedKeyColumns("id")
-                .withTableName("products");
-    }
-
-    public Product save(Product product) {
-        Map<String, Object> map = new HashMap<>();
-        map.put("name", product.getName());
-        map.put("price", product.getPrice());
-        map.put("image_url", product.getImageUrl());
-        Number key = insert.executeAndReturnKey(new MapSqlParameterSource(map));
-        product.setId(key.longValue());
-        return product;
-    }
-
-    public List<Product> findAll() {
-        String sql = "select * from products";
-        return jdbcTemplate.query(sql, PRODUCT_ROW_MAPPER);
-    }
-
-    public Optional<Product> findById(Long id) {
-        String sql = "select * from products where id=?";
-        try {
-            Product product= jdbcTemplate.queryForObject(sql,PRODUCT_ROW_MAPPER,id);
-            return Optional.of(product);
-        } catch (EmptyResultDataAccessException e) {
-            return Optional.empty();
-        }
-    }
-
-    public void update(Long id, Product product) {
-        String sql = "update products set name = ?, price = ?, image_url = ? where id = ?";
-        int affectedRows = jdbcTemplate.update(sql, product.getName(), product.getPrice(), product.getImageUrl(), id);
-        if (affectedRows == 0) {
-            throw new ProductNotFoundException("ID" + id + "에 해당하는 상품을 찾을 수 없습니다.");
-        }
-    }
-
-    public void delete(Long id) {
-        String sql = "delete from products where id = ?";
-        int affectedRows = jdbcTemplate.update(sql, id);
-        if (affectedRows == 0) {
-            throw new ProductNotFoundException("ID " + id + "에 해당하는 상품을 찾을 수 없어 삭제에 실패했습니다.");
-        }
-    }
-
-    private static final RowMapper<Product> PRODUCT_ROW_MAPPER = (rs, rowNum) -> new Product(
-            rs.getLong("id"),
-            rs.getString("name"),
-            rs.getInt("price"),
-            rs.getString("image_url")
-    );
 }
-
-
-

--- a/src/main/java/gift/repository/WishRepository.java
+++ b/src/main/java/gift/repository/WishRepository.java
@@ -1,73 +1,28 @@
 package gift.repository;
 
 import gift.dto.WishResponseDto;
+import gift.entity.Member;
+import gift.entity.Product;
 import gift.entity.Wish;
-import org.springframework.dao.EmptyResultDataAccessException;
-import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.jdbc.core.RowMapper;
-import org.springframework.jdbc.core.simple.SimpleJdbcInsert;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
-import java.util.HashMap;
+
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
 @Repository
-public class WishRepository {
-    private final JdbcTemplate jdbcTemplate;
-    private final SimpleJdbcInsert insert;
+public interface WishRepository extends JpaRepository<Wish, Long> {
 
-    public WishRepository(JdbcTemplate jdbcTemplate) {
-        this.jdbcTemplate = jdbcTemplate;
-        this.insert=new SimpleJdbcInsert(jdbcTemplate)
-                .withTableName("wish")
-                .usingGeneratedKeyColumns("id");
-    }
+    Optional<Wish> findByMemberAndProduct(Member member, Product product);
 
-    public Wish save(Wish wish) {
-        Map<String,Object> params=new HashMap<>();
-        params.put("member_id",wish.getMemberId());
-        params.put("product_id",wish.getProductId());
-        Number key=insert.executeAndReturnKey(params);
-        wish.setId(key.longValue());
-        return wish;
-    }
+    @Query("SELECT new gift.dto.WishResponseDto(w.id, p.id, p.name, p.price, p.imageUrl) " +
+            "FROM Wish w JOIN w.product p WHERE w.member.id = :memberId")
+    List<WishResponseDto> findWithProductByMember_Id(@Param("memberId") Long memberId);
 
-    public Optional<Wish> findByMemberIdAndProductId(Long memberId, Long productId) {
-        String sql = "SELECT id, member_id, product_id FROM wish WHERE member_id = ? AND product_id = ?";
-        try {
-            return Optional.ofNullable(jdbcTemplate.queryForObject(sql,WISH_ROW_MAPPER, memberId, productId));
-        } catch (EmptyResultDataAccessException e) {
-            return Optional.empty();
-        }
-    }
-
-    public List<WishResponseDto> findWishesWithProductByMemberId(Long memberId) {
-        String sql = "SELECT w.id as wish_id, p.id as product_id, p.name as product_name, p.price as product_price, p.image_url as product_image_url " +
-                "FROM wish w " +
-                "JOIN products p ON w.product_id = p.id " +
-                "WHERE w.member_id = ?";
-
-        RowMapper<WishResponseDto> responseDtoRowMapper = (rs, rowNum) -> new WishResponseDto(
-                rs.getLong("wish_id"),
-                rs.getLong("product_id"),
-                rs.getString("product_name"),
-                rs.getInt("product_price"),
-                rs.getString("product_image_url")
-        );
-
-        return jdbcTemplate.query(sql, responseDtoRowMapper, memberId);
-    }
-
-    public int deleteByIdAndMemberId(Long wishId, Long memberId) {
-        String sql = "DELETE FROM wish WHERE id = ? AND member_id = ?";
-        return jdbcTemplate.update(sql, wishId, memberId);
-    }
-
-    private final RowMapper<Wish> WISH_ROW_MAPPER=(rs,rowNum) ->
-    new Wish(
-            rs.getLong("id"),
-            rs.getLong("member_id"),
-            rs.getLong("product_id")
-    );
+    @Modifying
+    @Query("DELETE FROM Wish w WHERE w.id = :wishId AND w.member.id = :memberId")
+    int deleteByIdAndMember_Id(@Param("wishId") Long wishId, @Param("memberId") Long memberId);
 }

--- a/src/main/java/gift/repository/WishRepository.java
+++ b/src/main/java/gift/repository/WishRepository.java
@@ -23,6 +23,5 @@ public interface WishRepository extends JpaRepository<Wish, Long> {
     List<WishResponseDto> findWithProductByMember_Id(@Param("memberId") Long memberId);
 
     @Modifying
-    @Query("DELETE FROM Wish w WHERE w.id = :wishId AND w.member.id = :memberId")
-    int deleteByIdAndMember_Id(@Param("wishId") Long wishId, @Param("memberId") Long memberId);
+    int deleteByIdAndMemberId(Long wishId, Long memberId);
 }

--- a/src/main/java/gift/security/JwtTokenProvider.java
+++ b/src/main/java/gift/security/JwtTokenProvider.java
@@ -1,6 +1,5 @@
 package gift.security;
 
-import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
@@ -32,6 +31,7 @@ public class JwtTokenProvider {
                 .signWith(key)
                 .compact();
     }
+
     public void validateToken(String token) throws JwtException {
         Jwts.parser().verifyWith(key).build().parseSignedClaims(token);
     }

--- a/src/main/java/gift/service/MemberService.java
+++ b/src/main/java/gift/service/MemberService.java
@@ -14,7 +14,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
-@Transactional
+@Transactional(readOnly = true)
 public class MemberService {
     private final MemberRepository memberRepository;
     private final JwtTokenProvider jwtTokenProvider;
@@ -24,8 +24,9 @@ public class MemberService {
         this.jwtTokenProvider = jwtTokenProvider;
     }
 
+    @Transactional
     public TokenResponse register(RegisterRequestDto request) {
-        memberRepository.findByEmail(request.getEmail()).ifPresent(m-> {
+        memberRepository.findByEmail(request.getEmail()).ifPresent(m -> {
             throw new EmailAlreadyExistsException("이미 가입된 이메일입니다: " + request.getEmail());
         });
 
@@ -37,7 +38,6 @@ public class MemberService {
         return new TokenResponse(token);
     }
 
-    @Transactional(readOnly = true)
     public TokenResponse login(LoginRequestDto request) {
         Member member = memberRepository.findByEmail(request.getEmail())
                 .orElseThrow(() -> new LoginFailedException("가입되지 않은 이메일입니다."));
@@ -49,10 +49,9 @@ public class MemberService {
         return new TokenResponse(token);
     }
 
-    @Transactional(readOnly = true)
     public MemberProfileDto findMemberProfileById(Long memberId) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다. ID: " + memberId));
-        return new MemberProfileDto(member.getId(),member.getEmail());
+        return new MemberProfileDto(member.getId(), member.getEmail());
     }
 }

--- a/src/main/java/gift/service/ProductService.java
+++ b/src/main/java/gift/service/ProductService.java
@@ -13,24 +13,24 @@ import java.util.List;
 @Service
 @Transactional(readOnly = true)
 public class ProductService {
-    private final ProductRepository repository;
+    private final ProductRepository productrepository;
 
-    public ProductService(ProductRepository repository) {
-        this.repository = repository;
+    public ProductService(ProductRepository productrepository) {
+        this.productrepository = productrepository;
     }
 
     public List<Product> getAll() {
-        return repository.findAll();
+        return productrepository.findAll();
     }
 
     public Product getById(Long id) {
-        return repository.findById(id)
+        return productrepository.findById(id)
                 .orElseThrow(() -> new ProductNotFoundException("ID " + id + "에 해당하는 상품을 찾을 수 없습니다."));
     }
 
     @Transactional
     public Product create(CreateProductRequestDto dto) {
-        return repository.save(new Product(null, dto.getName(), dto.getPrice(), dto.getImageUrl()));
+        return productrepository.save(new Product(null, dto.getName(), dto.getPrice(), dto.getImageUrl()));
     }
 
     @Transactional
@@ -44,6 +44,6 @@ public class ProductService {
 
     @Transactional
     public void delete(Long id) {
-        repository.deleteById(id);
+        productrepository.deleteById(id);
     }
 }

--- a/src/main/java/gift/service/ProductService.java
+++ b/src/main/java/gift/service/ProductService.java
@@ -11,6 +11,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 
 @Service
+@Transactional(readOnly = true)
 public class ProductService {
     private final ProductRepository repository;
 
@@ -33,17 +34,16 @@ public class ProductService {
     }
 
     @Transactional
-    public Product update(Long id,UpdateProductRequestDto dto) {
-        Product productUpdate=getById(id);
+    public Product update(Long id, UpdateProductRequestDto dto) {
+        Product productUpdate = getById(id);
         productUpdate.setName(dto.getName());
         productUpdate.setPrice(dto.getPrice());
         productUpdate.setImageUrl(dto.getImageUrl());
-        repository.update(id,productUpdate);
         return productUpdate;
     }
 
     @Transactional
     public void delete(Long id) {
-        repository.delete(id);
+        repository.deleteById(id);
     }
 }

--- a/src/main/java/gift/service/WishService.java
+++ b/src/main/java/gift/service/WishService.java
@@ -3,6 +3,7 @@ package gift.service;
 import gift.dto.WishRequestDto;
 import gift.dto.WishResponseDto;
 import gift.entity.Member;
+import gift.entity.Product;
 import gift.entity.Wish;
 import gift.exception.ProductNotFoundException;
 import gift.exception.UnauthorizedWishAccessException;
@@ -15,7 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 
 @Service
-@Transactional
+@Transactional(readOnly = true)
 public class WishService {
     private final WishRepository wishRepository;
     private final ProductRepository productRepository;
@@ -27,28 +28,26 @@ public class WishService {
 
     @Transactional
     public Wish addWish(Member member, WishRequestDto wishRequestDto) {
-        Long productId = wishRequestDto.getProductId();
-        productRepository.findById(productId)
-                .orElseThrow(() -> new ProductNotFoundException("해당 상품을 찾을 수 없습니다. ID: " + productId));
+        Product product = productRepository.findById(wishRequestDto.getProductId())
+                .orElseThrow(() -> new ProductNotFoundException("해당 상품을 찾을 수 없습니다."));
 
-        wishRepository.findByMemberIdAndProductId(member.getId(), productId).ifPresent(w -> {
+        wishRepository.findByMemberAndProduct(member, product).ifPresent(w -> {
             throw new WishAlreadyExistsException("이미 위시리스트에 추가된 상품입니다.");
         });
 
-        Wish wish= new Wish(null,member.getId(),productId);
+        Wish wish = new Wish(member, product);
         return wishRepository.save(wish);
     }
 
-    @Transactional
     public List<WishResponseDto> getWishesByMember(Member member) {
-        return wishRepository.findWishesWithProductByMemberId(member.getId());
+        return wishRepository.findWithProductByMember_Id(member.getId());
     }
 
     @Transactional
     public void deleteWish(Long wishId, Member member) {
-        int affectedRows = wishRepository.deleteByIdAndMemberId(wishId, member.getId());
-        if (affectedRows == 0) {
-            throw new UnauthorizedWishAccessException("삭제할 수 없는 위시리스트 항목입니다.");
+        int deletedCount = wishRepository.deleteByIdAndMember_Id(wishId, member.getId());
+        if (deletedCount == 0) {
+            throw new UnauthorizedWishAccessException("삭제 권한이 없거나 존재하지 않는 위시리스트 항목입니다.");
         }
     }
 }

--- a/src/main/java/gift/service/WishService.java
+++ b/src/main/java/gift/service/WishService.java
@@ -45,7 +45,7 @@ public class WishService {
 
     @Transactional
     public void deleteWish(Long wishId, Member member) {
-        int deletedCount = wishRepository.deleteByIdAndMember_Id(wishId, member.getId());
+        int deletedCount = wishRepository.deleteByIdAndMemberId(wishId, member.getId());
         if (deletedCount == 0) {
             throw new UnauthorizedWishAccessException("삭제 권한이 없거나 존재하지 않는 위시리스트 항목입니다.");
         }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,16 +1,13 @@
 spring.application.name=spring-gift
-
 spring.datasource.url=jdbc:h2:mem:test
 spring.datasource.driver-class-name=org.h2.Driver
 spring.datasource.username=sa
 spring.datasource.password=
-
+spring.jpa.hibernate.ddl-auto=none
 spring.sql.init.mode=always
 spring.sql.init.schema-locations=classpath:sql/schema.sql
 spring.sql.init.data-locations=classpath:sql/data.sql
-
 spring.h2.console.enabled=true
 spring.h2.console.path=/h2-console
-
 security.jwt.token.secret-key=Yn2kjibddFAWtnPJ2AFlL8WXmohJMCvigQggaEypa5E=
 security.jwt.token.expire-length=3600000

--- a/src/main/resources/sql/data.sql
+++ b/src/main/resources/sql/data.sql
@@ -1,3 +1,3 @@
-INSERT INTO products (name, price, image_url) VALUES
-('아메리카노', 4000, 'https://images.unsplash.com/photo-1509042239860-f550ce710b93?auto=format&fit=crop&w=800&q=80'),
-('카페라떼', 4500, 'https://images.unsplash.com/photo-1511920170033-f8396924c348?auto=format&fit=crop&w=800&q=80');
+INSERT INTO products (name, price, image_url)
+VALUES ('아메리카노', 4000, 'https://images.unsplash.com/photo-1509042239860-f550ce710b93?auto=format&fit=crop&w=800&q=80'),
+       ('카페라떼', 4500, 'https://images.unsplash.com/photo-1511920170033-f8396924c348?auto=format&fit=crop&w=800&q=80');

--- a/src/main/resources/sql/schema.sql
+++ b/src/main/resources/sql/schema.sql
@@ -1,21 +1,24 @@
-Create Table products(
- id BIGINT AUTO_INCREMENT PRIMARY KEY,
- name VARCHAR(255) NOT NULL,
- price INT NOT NULL,
- image_url VARCHAR(1000) NOT NULL
+Create Table products
+(
+    id        BIGINT AUTO_INCREMENT PRIMARY KEY,
+    name      VARCHAR(255)  NOT NULL,
+    price     INT           NOT NULL,
+    image_url VARCHAR(1000) NOT NULL
 );
 
-CREATE TABLE member (
-id BIGINT AUTO_INCREMENT PRIMARY KEY,
-email VARCHAR(255) NOT NULL UNIQUE,
-password VARCHAR(255) NOT NULL
+CREATE TABLE member
+(
+    id       BIGINT AUTO_INCREMENT PRIMARY KEY,
+    email    VARCHAR(255) NOT NULL UNIQUE,
+    password VARCHAR(255) NOT NULL
 );
 
-CREATE TABLE wish(
-     id BIGINT AUTO_INCREMENT PRIMARY KEY,
-     member_id BIGINT NOT NULL,
-     product_id BIGINT NOT NULL,
-     FOREIGN KEY (member_id) REFERENCES member(id) ON DELETE CASCADE,
-     FOREIGN KEY (product_id) REFERENCES products(id) ON DELETE CASCADE,
-     UNIQUE (member_id, product_id)
+CREATE TABLE wish
+(
+    id         BIGINT AUTO_INCREMENT PRIMARY KEY,
+    member_id  BIGINT NOT NULL,
+    product_id BIGINT NOT NULL,
+    FOREIGN KEY (member_id) REFERENCES member (id) ON DELETE CASCADE,
+    FOREIGN KEY (product_id) REFERENCES products (id) ON DELETE CASCADE,
+    UNIQUE (member_id, product_id)
 );

--- a/src/main/resources/templates/admin/products/detail.html
+++ b/src/main/resources/templates/admin/products/detail.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org">
 <head>
-    <meta charset="UTF-8" />
+    <meta charset="UTF-8"/>
     <title>상품 상세 보기</title>
 </head>
 <body>
@@ -26,7 +26,7 @@
     </tr>
 </table>
 
-<br />
+<br/>
 <a th:href="@{/admin/products}">← 목록으로 돌아가기</a>
 <a th:href="@{'/admin/products/' + ${product.id} + '/edit'}">수정</a>
 <form th:action="@{'/admin/products/' + ${product.id} + '/delete'}" method="post" style="display:inline;">

--- a/src/main/resources/templates/admin/products/edit.html
+++ b/src/main/resources/templates/admin/products/edit.html
@@ -1,29 +1,29 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org">
 <head>
-  <meta charset="UTF-8" />
-  <title>상품 수정</title>
+    <meta charset="UTF-8"/>
+    <title>상품 수정</title>
 </head>
 <body>
 <h1>상품 수정</h1>
 
 <form th:action="@{|/admin/products/${productId}/edit|}" th:object="${product}" method="post">
-  <label>상품명:
-    <input type="text" th:field="*{name}" />
-    <div class="error" th:if="${#fields.hasErrors('name')}" th:errors="*{name}"></div>
-  </label>
-  <br />
-  <label>가격:
-    <input type="number" th:field="*{price}" />
-    <div class="error" th:if="${#fields.hasErrors('price')}" th:errors="*{price}"></div>
-  </label>
-  <br />
-  <label>이미지 URL:
-    <input type="text" th:field="*{imageUrl}" />
-    <div class="error" th:if="${#fields.hasErrors('imageUrl')}" th:errors="*{imageUrl}"></div>
-  </label>
-  <br />
-  <button type="submit">수정</button>
+    <label>상품명:
+        <input type="text" th:field="*{name}"/>
+        <div class="error" th:if="${#fields.hasErrors('name')}" th:errors="*{name}"></div>
+    </label>
+    <br/>
+    <label>가격:
+        <input type="number" th:field="*{price}"/>
+        <div class="error" th:if="${#fields.hasErrors('price')}" th:errors="*{price}"></div>
+    </label>
+    <br/>
+    <label>이미지 URL:
+        <input type="text" th:field="*{imageUrl}"/>
+        <div class="error" th:if="${#fields.hasErrors('imageUrl')}" th:errors="*{imageUrl}"></div>
+    </label>
+    <br/>
+    <button type="submit">수정</button>
 </form>
 
 

--- a/src/main/resources/templates/admin/products/list.html
+++ b/src/main/resources/templates/admin/products/list.html
@@ -1,39 +1,39 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org">
 <head>
-  <meta charset="UTF-8">
-  <title>상품목록</title>
+    <meta charset="UTF-8">
+    <title>상품목록</title>
 </head>
 <body>
 <h1>상품목록</h1>
 
 <a th:href="@{/admin/products/new}">+ 새 상품 등록</a>
 <table border="1">
-  <thead>
-  <tr>
-    <th>ID</th>
-    <th>이름</th>
-    <th>가격</th>
-    <th>이미지</th>
-  </tr>
-  </thead>
-  <tbody>
-  <tr th:each="product : ${products}">
-    <td th:text="${product.id}">1</td>
-    <td th:text="${product.name}">아이스 아메리카노</td>
-    <td th:text="${product.price}">4500</td>
-    <td>
-      <img th:src="${product.imageUrl}" width="100" alt="이미지"/>
-    </td>
-    <td>
-      <a th:href="@{'/admin/products/' + ${product.id}}">상세</a>
-      <a th:href="@{'/admin/products/' + ${product.id} + '/edit'}">수정</a>
-      <form th:action="@{'/admin/products/' + ${product.id} + '/delete'}" method="post" style="display:inline;">
-        <button type="submit">삭제</button>
-      </form>
-    </td>
-  </tr>
-  </tbody>
+    <thead>
+    <tr>
+        <th>ID</th>
+        <th>이름</th>
+        <th>가격</th>
+        <th>이미지</th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr th:each="product : ${products}">
+        <td th:text="${product.id}">1</td>
+        <td th:text="${product.name}">아이스 아메리카노</td>
+        <td th:text="${product.price}">4500</td>
+        <td>
+            <img th:src="${product.imageUrl}" width="100" alt="이미지"/>
+        </td>
+        <td>
+            <a th:href="@{'/admin/products/' + ${product.id}}">상세</a>
+            <a th:href="@{'/admin/products/' + ${product.id} + '/edit'}">수정</a>
+            <form th:action="@{'/admin/products/' + ${product.id} + '/delete'}" method="post" style="display:inline;">
+                <button type="submit">삭제</button>
+            </form>
+        </td>
+    </tr>
+    </tbody>
 </table>
 </body>
 </html>

--- a/src/main/resources/templates/admin/products/new.html
+++ b/src/main/resources/templates/admin/products/new.html
@@ -1,29 +1,29 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org">
 <head>
-  <meta charset="UTF-8" />
-  <title>상품 등록</title>
+    <meta charset="UTF-8"/>
+    <title>상품 등록</title>
 </head>
 <body>
 <h1>상품 등록</h1>
 
 <form th:action="@{/admin/products}" th:object="${product}" method="post">
-  <label>상품명:
-    <input type="text" th:field="*{name}" />
-    <div class.="error" th:if="${#fields.hasErrors('name')}" th:errors="*{name}"></div>
-  </label>
-  <br />
-  <label>가격:
-    <input type="number" th:field="*{price}" />
-    <div class.="error" th:if="${#fields.hasErrors('price')}" th:errors="*{price}"></div>
-  </label>
-  <br />
-  <label>이미지 URL:
-    <input type="text" th:field="*{imageUrl}" />
-    <div class.="error" th:if="${#fields.hasErrors('imageUrl')}" th:errors="*{imageUrl}"></div>
-  </label>
-  <br />
-  <button type="submit">등록</button>
+    <label>상품명:
+        <input type="text" th:field="*{name}"/>
+        <div class.="error" th:if="${#fields.hasErrors('name')}" th:errors="*{name}"></div>
+    </label>
+    <br/>
+    <label>가격:
+        <input type="number" th:field="*{price}"/>
+        <div class.="error" th:if="${#fields.hasErrors('price')}" th:errors="*{price}"></div>
+    </label>
+    <br/>
+    <label>이미지 URL:
+        <input type="text" th:field="*{imageUrl}"/>
+        <div class.="error" th:if="${#fields.hasErrors('imageUrl')}" th:errors="*{imageUrl}"></div>
+    </label>
+    <br/>
+    <button type="submit">등록</button>
 </form>
 
 <a th:href="@{/admin/products}">목록으로 돌아가기</a>

--- a/src/main/resources/templates/error/400.html
+++ b/src/main/resources/templates/error/400.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 <html lang="ko">
-<head><meta charset="UTF-8"><title>잘못된 요청</title></head>
+<head>
+    <meta charset="UTF-8">
+    <title>잘못된 요청</title></head>
 <body>
 <h1>⚠️ 400 - 잘못된 요청</h1>
 <p th:text="${errorMessage}"></p>

--- a/src/main/resources/templates/error/404.html
+++ b/src/main/resources/templates/error/404.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 <html lang="ko">
-<head><meta charset="UTF-8"><title>페이지 없음</title></head>
+<head>
+    <meta charset="UTF-8">
+    <title>페이지 없음</title></head>
 <body>
 <h1>🚫 404 - 페이지를 찾을 수 없습니다</h1>
 <p th:text="${errorMessage}"></p>

--- a/src/main/resources/templates/error/500.html
+++ b/src/main/resources/templates/error/500.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 <html lang="ko">
-<head><meta charset="UTF-8"><title>서버 오류</title></head>
+<head>
+    <meta charset="UTF-8">
+    <title>서버 오류</title></head>
 <body>
 <h1>💥 500 - 서버 내부 오류</h1>
 <p th:text="${errorMessage}"></p>

--- a/src/main/resources/templates/member/login.html
+++ b/src/main/resources/templates/member/login.html
@@ -1,57 +1,113 @@
 <!DOCTYPE html>
 <html lang="ko">
 <head>
-  <meta charset="UTF-8">
-  <title>로그인</title>
-  <style>
-    body { font-family: sans-serif; display: flex; justify-content: center; align-items: center; height: 100vh; background-color: #f4f4f4; margin: 0;}
-    .container { width: 320px; padding: 25px; border: 1px solid #ddd; border-radius: 8px; background-color: white; box-shadow: 0 2px 4px rgba(0,0,0,0.1); }
-    h2 { text-align: center; color: #333; }
-    input { width: 95%; padding: 10px; margin-bottom: 12px; border: 1px solid #ccc; border-radius: 4px; }
-    button { width: 100%; padding: 10px; background-color: #28a745; color: white; border: none; border-radius: 4px; cursor: pointer; font-size: 16px; }
-    button:hover { background-color: #218838; }
-    p { text-align: center; }
-    .error { color: red; font-size: 0.9em; text-align: center; height: 1.2em;}
-    a { color: #007bff; text-decoration: none; }
-    a:hover { text-decoration: underline; }
-  </style>
+    <meta charset="UTF-8">
+    <title>로그인</title>
+    <style>
+        body {
+            font-family: sans-serif;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            height: 100vh;
+            background-color: #f4f4f4;
+            margin: 0;
+        }
+
+        .container {
+            width: 320px;
+            padding: 25px;
+            border: 1px solid #ddd;
+            border-radius: 8px;
+            background-color: white;
+            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+        }
+
+        h2 {
+            text-align: center;
+            color: #333;
+        }
+
+        input {
+            width: 95%;
+            padding: 10px;
+            margin-bottom: 12px;
+            border: 1px solid #ccc;
+            border-radius: 4px;
+        }
+
+        button {
+            width: 100%;
+            padding: 10px;
+            background-color: #28a745;
+            color: white;
+            border: none;
+            border-radius: 4px;
+            cursor: pointer;
+            font-size: 16px;
+        }
+
+        button:hover {
+            background-color: #218838;
+        }
+
+        p {
+            text-align: center;
+        }
+
+        .error {
+            color: red;
+            font-size: 0.9em;
+            text-align: center;
+            height: 1.2em;
+        }
+
+        a {
+            color: #007bff;
+            text-decoration: none;
+        }
+
+        a:hover {
+            text-decoration: underline;
+        }
+    </style>
 </head>
 <body>
 <div class="container">
-  <h2>로그인</h2>
-  <form id="loginForm">
-    <input type="email" id="email" placeholder="이메일" required>
-    <input type="password" id="password" placeholder="비밀번호" required>
-    <p id="errorMessage" class="error"></p>
-    <button type="submit">로그인</button>
-  </form>
-  <p>계정이 없으신가요? <a href="/register">회원가입</a></p>
+    <h2>로그인</h2>
+    <form id="loginForm">
+        <input type="email" id="email" placeholder="이메일" required>
+        <input type="password" id="password" placeholder="비밀번호" required>
+        <p id="errorMessage" class="error"></p>
+        <button type="submit">로그인</button>
+    </form>
+    <p>계정이 없으신가요? <a href="/register">회원가입</a></p>
 </div>
 <script>
-  document.getElementById('loginForm').addEventListener('submit', async function(event) {
-    event.preventDefault();
-    const email = document.getElementById('email').value;
-    const password = document.getElementById('password').value;
-    const errorMessage = document.getElementById('errorMessage');
-    errorMessage.textContent = '';
-    try {
-      const response = await fetch('/api/members/login', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ email, password })
-      });
-      const data = await response.json();
-      if (!response.ok) {
-        throw new Error(data.message || '로그인에 실패했습니다.');
-      }
-      localStorage.setItem('accessToken', data.token);
-      alert('로그인 성공!');
-      window.location.href = '/wishes';
+    document.getElementById('loginForm').addEventListener('submit', async function (event) {
+        event.preventDefault();
+        const email = document.getElementById('email').value;
+        const password = document.getElementById('password').value;
+        const errorMessage = document.getElementById('errorMessage');
+        errorMessage.textContent = '';
+        try {
+            const response = await fetch('/api/members/login', {
+                method: 'POST',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify({email, password})
+            });
+            const data = await response.json();
+            if (!response.ok) {
+                throw new Error(data.message || '로그인에 실패했습니다.');
+            }
+            localStorage.setItem('accessToken', data.token);
+            alert('로그인 성공!');
+            window.location.href = '/wishes';
 
-    } catch (error) {
-      errorMessage.textContent = error.message;
-    }
-  });
+        } catch (error) {
+            errorMessage.textContent = error.message;
+        }
+    });
 </script>
 </body>
 </html>

--- a/src/main/resources/templates/member/myinfo.html
+++ b/src/main/resources/templates/member/myinfo.html
@@ -4,14 +4,65 @@
     <meta charset="UTF-8">
     <title>내 정보</title>
     <style>
-        body { font-family: sans-serif; display: flex; justify-content: center; align-items: center; height: 100vh; background-color: #f4f4f4; margin: 0; }
-        .container { width: 320px; padding: 25px; border: 1px solid #ddd; border-radius: 8px; background-color: white; box-shadow: 0 2px 4px rgba(0,0,0,0.1); }
-        h2 { text-align: center; color: #333; margin-top: 0; }
-        .info-group { margin-bottom: 15px; }
-        .info-label { font-weight: bold; color: #555; display: block; margin-bottom: 5px; }
-        .info-data { padding: 10px; background-color: #f9f9f9; border: 1px solid #eee; border-radius: 4px; word-wrap: break-word; }
-        button { width: 100%; padding: 10px; background-color: #dc3545; color: white; border: none; border-radius: 4px; cursor: pointer; font-size: 16px; margin-top: 15px; }
-        button:hover { background-color: #c82333; }
+        body {
+            font-family: sans-serif;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            height: 100vh;
+            background-color: #f4f4f4;
+            margin: 0;
+        }
+
+        .container {
+            width: 320px;
+            padding: 25px;
+            border: 1px solid #ddd;
+            border-radius: 8px;
+            background-color: white;
+            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+        }
+
+        h2 {
+            text-align: center;
+            color: #333;
+            margin-top: 0;
+        }
+
+        .info-group {
+            margin-bottom: 15px;
+        }
+
+        .info-label {
+            font-weight: bold;
+            color: #555;
+            display: block;
+            margin-bottom: 5px;
+        }
+
+        .info-data {
+            padding: 10px;
+            background-color: #f9f9f9;
+            border: 1px solid #eee;
+            border-radius: 4px;
+            word-wrap: break-word;
+        }
+
+        button {
+            width: 100%;
+            padding: 10px;
+            background-color: #dc3545;
+            color: white;
+            border: none;
+            border-radius: 4px;
+            cursor: pointer;
+            font-size: 16px;
+            margin-top: 15px;
+        }
+
+        button:hover {
+            background-color: #c82333;
+        }
     </style>
 </head>
 <body>
@@ -28,7 +79,7 @@
     <button onclick="logout()">로그아웃</button>
 </div>
 <script>
-    window.onload = async function() {
+    window.onload = async function () {
         const token = localStorage.getItem('accessToken');
 
         if (!token) {
@@ -40,7 +91,7 @@
         try {
             const response = await fetch('/api/members/me', {
                 method: 'GET',
-                headers: { 'Authorization': 'Bearer ' + token }
+                headers: {'Authorization': 'Bearer ' + token}
             });
 
             if (response.ok) {

--- a/src/main/resources/templates/member/register.html
+++ b/src/main/resources/templates/member/register.html
@@ -4,16 +4,72 @@
     <meta charset="UTF-8">
     <title>회원가입</title>
     <style>
-        body { font-family: sans-serif; display: flex; justify-content: center; align-items: center; height: 100vh; background-color: #f4f4f4; margin: 0;}
-        .container { width: 320px; padding: 25px; border: 1px solid #ddd; border-radius: 8px; background-color: white; box-shadow: 0 2px 4px rgba(0,0,0,0.1); }
-        h2 { text-align: center; color: #333; }
-        input { width: 95%; padding: 10px; margin-bottom: 12px; border: 1px solid #ccc; border-radius: 4px; }
-        button { width: 100%; padding: 10px; background-color: #007bff; color: white; border: none; border-radius: 4px; cursor: pointer; font-size: 16px; }
-        button:hover { background-color: #0056b3; }
-        p { text-align: center; }
-        .error { color: red; font-size: 0.9em; text-align: center; height: 1.2em;}
-        a { color: #007bff; text-decoration: none; }
-        a:hover { text-decoration: underline; }
+        body {
+            font-family: sans-serif;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            height: 100vh;
+            background-color: #f4f4f4;
+            margin: 0;
+        }
+
+        .container {
+            width: 320px;
+            padding: 25px;
+            border: 1px solid #ddd;
+            border-radius: 8px;
+            background-color: white;
+            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+        }
+
+        h2 {
+            text-align: center;
+            color: #333;
+        }
+
+        input {
+            width: 95%;
+            padding: 10px;
+            margin-bottom: 12px;
+            border: 1px solid #ccc;
+            border-radius: 4px;
+        }
+
+        button {
+            width: 100%;
+            padding: 10px;
+            background-color: #007bff;
+            color: white;
+            border: none;
+            border-radius: 4px;
+            cursor: pointer;
+            font-size: 16px;
+        }
+
+        button:hover {
+            background-color: #0056b3;
+        }
+
+        p {
+            text-align: center;
+        }
+
+        .error {
+            color: red;
+            font-size: 0.9em;
+            text-align: center;
+            height: 1.2em;
+        }
+
+        a {
+            color: #007bff;
+            text-decoration: none;
+        }
+
+        a:hover {
+            text-decoration: underline;
+        }
     </style>
 </head>
 <body>
@@ -37,8 +93,8 @@
         try {
             const response = await fetch('/api/members/register', {
                 method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ email, password })
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify({email, password})
             });
             const data = await response.json();
             if (!response.ok) {

--- a/src/main/resources/templates/member/wishlist.html
+++ b/src/main/resources/templates/member/wishlist.html
@@ -4,18 +4,96 @@
     <meta charset="UTF-8">
     <title>내 위시리스트</title>
     <style>
-        body { font-family: sans-serif; max-width: 800px; margin: 40px auto; padding: 20px; background-color: #f9f9f9; color: #333; }
-        h1, h2 { text-align: center; color: #2c3e50; }
-        .wish-form { background-color: white; padding: 20px; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); margin-bottom: 30px; }
-        .wish-form input { width: calc(100% - 90px); padding: 10px; border: 1px solid #ccc; border-radius: 4px; }
-        .wish-form button { width: 80px; padding: 10px; background-color: #28a745; color: white; border: none; border-radius: 4px; cursor: pointer; }
-        .wish-list { list-style: none; padding: 0; }
-        .wish-item { display: flex; align-items: center; background-color: white; padding: 15px; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); margin-bottom: 10px; }
-        .wish-item img { width: 60px; height: 60px; border-radius: 4px; margin-right: 15px; }
-        .wish-item-info { flex-grow: 1; }
-        .wish-item-info strong { font-size: 1.1em; }
-        .wish-item-delete { padding: 8px 12px; background-color: #e74c3c; color: white; border: none; border-radius: 4px; cursor: pointer; }
-        #logout-button { display: block; width: 100px; margin: 30px auto 0; padding: 10px; background-color: #3498db; color: white; text-align: center; border-radius: 4px; cursor: pointer; text-decoration: none; }
+        body {
+            font-family: sans-serif;
+            max-width: 800px;
+            margin: 40px auto;
+            padding: 20px;
+            background-color: #f9f9f9;
+            color: #333;
+        }
+
+        h1, h2 {
+            text-align: center;
+            color: #2c3e50;
+        }
+
+        .wish-form {
+            background-color: white;
+            padding: 20px;
+            border-radius: 8px;
+            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+            margin-bottom: 30px;
+        }
+
+        .wish-form input {
+            width: calc(100% - 90px);
+            padding: 10px;
+            border: 1px solid #ccc;
+            border-radius: 4px;
+        }
+
+        .wish-form button {
+            width: 80px;
+            padding: 10px;
+            background-color: #28a745;
+            color: white;
+            border: none;
+            border-radius: 4px;
+            cursor: pointer;
+        }
+
+        .wish-list {
+            list-style: none;
+            padding: 0;
+        }
+
+        .wish-item {
+            display: flex;
+            align-items: center;
+            background-color: white;
+            padding: 15px;
+            border-radius: 8px;
+            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+            margin-bottom: 10px;
+        }
+
+        .wish-item img {
+            width: 60px;
+            height: 60px;
+            border-radius: 4px;
+            margin-right: 15px;
+        }
+
+        .wish-item-info {
+            flex-grow: 1;
+        }
+
+        .wish-item-info strong {
+            font-size: 1.1em;
+        }
+
+        .wish-item-delete {
+            padding: 8px 12px;
+            background-color: #e74c3c;
+            color: white;
+            border: none;
+            border-radius: 4px;
+            cursor: pointer;
+        }
+
+        #logout-button {
+            display: block;
+            width: 100px;
+            margin: 30px auto 0;
+            padding: 10px;
+            background-color: #3498db;
+            color: white;
+            text-align: center;
+            border-radius: 4px;
+            cursor: pointer;
+            text-decoration: none;
+        }
     </style>
 </head>
 <body>
@@ -40,7 +118,7 @@
     const wishListElement = document.getElementById('wish-list');
 
     // 페이지 로드 시 실행
-    window.onload = function() {
+    window.onload = function () {
         if (!token) {
             alert('로그인이 필요합니다.');
             window.location.href = '/login';
@@ -52,7 +130,7 @@
     async function loadWishes() {
         try {
             const response = await fetch('/api/wishes', {
-                headers: { 'Authorization': 'Bearer ' + token }
+                headers: {'Authorization': 'Bearer ' + token}
             });
             if (!response.ok) throw new Error('위시리스트를 불러오는데 실패했습니다.');
 
@@ -82,7 +160,7 @@
         }
     }
 
-    document.getElementById('add-wish-form').addEventListener('submit', async function(e) {
+    document.getElementById('add-wish-form').addEventListener('submit', async function (e) {
         e.preventDefault();
         const productId = document.getElementById('product-id').value;
         if (!productId) return;
@@ -94,7 +172,7 @@
                     'Authorization': 'Bearer ' + token,
                     'Content-Type': 'application/json'
                 },
-                body: JSON.stringify({ productId: Number(productId) })
+                body: JSON.stringify({productId: Number(productId)})
             });
 
             if (response.status === 201) {
@@ -109,7 +187,7 @@
             alert(error.message);
         }
     });
-    wishListElement.addEventListener('click', async function(e) {
+    wishListElement.addEventListener('click', async function (e) {
         if (e.target && e.target.classList.contains('wish-item-delete')) {
             const wishId = e.target.dataset.wishId;
             if (!confirm('정말로 이 상품을 삭제하시겠습니까?')) return;
@@ -117,7 +195,7 @@
             try {
                 const response = await fetch(`/api/wishes/${wishId}`, {
                     method: 'DELETE',
-                    headers: { 'Authorization': 'Bearer ' + token }
+                    headers: {'Authorization': 'Bearer ' + token}
                 });
 
                 if (response.status === 204) {
@@ -132,7 +210,7 @@
             }
         }
     });
-    document.getElementById('logout-button').addEventListener('click', function(e) {
+    document.getElementById('logout-button').addEventListener('click', function (e) {
         e.preventDefault();
         localStorage.removeItem('accessToken');
         alert('로그아웃 되었습니다.');

--- a/src/test/java/gift/controller/admin/AdminProductControllerTest.java
+++ b/src/test/java/gift/controller/admin/AdminProductControllerTest.java
@@ -1,23 +1,21 @@
 package gift.controller.admin;
 
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
-
 import gift.dto.CreateProductRequestDto;
 import gift.entity.Product;
 import gift.service.ProductService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
 
 @SpringBootTest
 @AutoConfigureMockMvc

--- a/src/test/java/gift/controller/api/MemberApiControllerTest.java
+++ b/src/test/java/gift/controller/api/MemberApiControllerTest.java
@@ -20,7 +20,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @SpringBootTest
 @AutoConfigureMockMvc
-@Sql(scripts="/cleanup.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+@Sql(scripts = "/cleanup.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
 public class MemberApiControllerTest {
 
     @Autowired

--- a/src/test/java/gift/controller/api/WishApiControllerTest.java
+++ b/src/test/java/gift/controller/api/WishApiControllerTest.java
@@ -14,13 +14,14 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
 @AutoConfigureMockMvc
 @Transactional
 @Sql("/test-data.sql")
-public class WishApiControllerTest{
+public class WishApiControllerTest {
 
     @Autowired
     private MockMvc mockMvc;

--- a/src/test/java/gift/repository/WishRepositoryTest.java
+++ b/src/test/java/gift/repository/WishRepositoryTest.java
@@ -1,0 +1,62 @@
+package gift.repository;
+
+import gift.entity.Member;
+import gift.entity.Product;
+import gift.entity.Wish;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+public class WishRepositoryTest {
+
+    @Autowired
+    private TestEntityManager entityManager;
+
+    @Autowired
+    private WishRepository wishRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private ProductRepository productRepository;
+
+    @Test
+    void saveWishWithRelations() {
+        Member member = entityManager.persist(new Member("test@example.com", "password"));
+        Product product = entityManager.persist(new Product("테스트 상품", 10000, "test.jpg"));
+        Wish wish = new Wish(member, product);
+        wishRepository.save(wish);
+        entityManager.flush();
+        entityManager.clear();
+        Wish foundWish = wishRepository.findById(wish.getId()).orElseThrow();
+
+        assertThat(foundWish.getMember().getId()).isEqualTo(member.getId());
+        assertThat(foundWish.getProduct().getId()).isEqualTo(product.getId());
+        assertThat(foundWish.getMember().getEmail()).isEqualTo("test@example.com");
+    }
+
+    @Test
+    void findWishesFromMember() {
+        Member member = new Member("user@example.com", "password");
+        Product product1 = productRepository.save(new Product("상품1", 1000, "1.jpg"));
+        Product product2 = productRepository.save(new Product("상품2", 2000, "2.jpg"));
+
+        member.getWishes().add(new Wish(member, product1));
+        member.getWishes().add(new Wish(member, product2));
+        memberRepository.save(member);
+
+        entityManager.flush();
+        entityManager.clear();
+
+        Member foundMember = memberRepository.findById(member.getId()).orElseThrow();
+
+        assertThat(foundMember.getWishes()).hasSize(2);
+        assertThat(foundMember.getWishes().get(0).getProduct().getName()).isEqualTo("상품1");
+    }
+}
+

--- a/src/test/java/gift/repository/WishRepositoryTest.java
+++ b/src/test/java/gift/repository/WishRepositoryTest.java
@@ -59,4 +59,3 @@ public class WishRepositoryTest {
         assertThat(foundMember.getWishes().get(0).getProduct().getName()).isEqualTo("상품1");
     }
 }
-

--- a/src/test/java/gift/service/MemberServiceTest.java
+++ b/src/test/java/gift/service/MemberServiceTest.java
@@ -1,7 +1,5 @@
 package gift.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import gift.dto.LoginRequestDto;
 import gift.dto.MemberProfileDto;
 import gift.dto.RegisterRequestDto;
@@ -18,12 +16,14 @@ import org.mindrot.jbcrypt.BCrypt;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.test.context.jdbc.Sql;
 
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
-import java.util.Optional;
 
 @ExtendWith(MockitoExtension.class)
 public class MemberServiceTest {
@@ -40,19 +40,20 @@ public class MemberServiceTest {
     private RegisterRequestDto registerRequestDto;
     private LoginRequestDto loginRequestDto;
     private Member member;
-    private String rawPassword="password";
+    private String rawPassword = "password";
+
     @BeforeEach
     void setUp() {
-        registerRequestDto=new RegisterRequestDto();
+        registerRequestDto = new RegisterRequestDto();
         registerRequestDto.setEmail("test@email.com");
         registerRequestDto.setPassword(rawPassword);
 
-        loginRequestDto=new LoginRequestDto();
+        loginRequestDto = new LoginRequestDto();
         loginRequestDto.setEmail("test@email.com");
         loginRequestDto.setPassword(rawPassword);
 
-        String hashPassword= BCrypt.hashpw(rawPassword, BCrypt.gensalt());
-        member=new Member(1L,"test@email.com",hashPassword);
+        String hashPassword = BCrypt.hashpw(rawPassword, BCrypt.gensalt());
+        member = new Member(1L, "test@email.com", hashPassword);
     }
 
 

--- a/src/test/java/gift/service/ProductServiceTest.java
+++ b/src/test/java/gift/service/ProductServiceTest.java
@@ -1,86 +1,70 @@
 package gift.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
 import gift.dto.CreateProductRequestDto;
 import gift.dto.UpdateProductRequestDto;
 import gift.entity.Product;
 import gift.exception.ProductNotFoundException;
-import org.junit.jupiter.api.BeforeEach;
+import gift.repository.ProductRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @SpringBootTest
 @Transactional
+@ActiveProfiles("test")
 public class ProductServiceTest {
 
     @Autowired
     private ProductService productService;
-    private Product savedProduct;
 
-    @BeforeEach
-    void setUp() {
-        CreateProductRequestDto createDto = new CreateProductRequestDto();
-        createDto.setName("기본 상품");
-        createDto.setPrice(15000);
-        createDto.setImageUrl("default.jpg");
-        savedProduct = productService.create(createDto);
-    }
+    @Autowired
+    private ProductRepository productRepository;
 
     @Test
-    void getProductById_Success() {
-        Product foundProduct = productService.getById(savedProduct.getId());
-        assertThat(foundProduct.getName()).isEqualTo("기본 상품");
-    }
+    void updateProductWithDirtyChecking() {
+        Product originalProduct = productRepository.save(new Product("원본 상품", 10000, "original.jpg"));
+        Long productId = originalProduct.getId();
 
-    @Test
-    void getProductByNonExistentId() {
-        assertThatThrownBy(() -> productService.getById(99999L))
-                .isInstanceOf(ProductNotFoundException.class);
-    }
+        UpdateProductRequestDto updateRequest = new UpdateProductRequestDto();
+        updateRequest.setName("수정된 상품");
+        updateRequest.setPrice(15000);
+        updateRequest.setImageUrl("updated.jpg");
+        productService.update(productId, updateRequest);
+        Product updatedProduct = productRepository.findById(productId).orElseThrow();
 
-    @Test
-    void updateProduct_Success() {
-        UpdateProductRequestDto updateDto = new UpdateProductRequestDto();
-        updateDto.setName("수정된 상품");
-        updateDto.setPrice(20000);
-        updateDto.setImageUrl("updated.jpg");
-
-        productService.update(savedProduct.getId(), updateDto);
-
-        Product updatedProduct = productService.getById(savedProduct.getId());
         assertThat(updatedProduct.getName()).isEqualTo("수정된 상품");
-    }
-
-
-    @Test
-    void getAllProducts() {
-        CreateProductRequestDto anotherDto = new CreateProductRequestDto();
-        anotherDto.setName("추가 상품");
-        anotherDto.setPrice(5000);
-        anotherDto.setImageUrl("another.jpg");
-        productService.create(anotherDto);
-        List<Product> products = productService.getAll();
-        assertThat(products).hasSize(4);
+        assertThat(updatedProduct.getPrice()).isEqualTo(15000);
     }
 
     @Test
-    void deleteProduct_Success() {
-        Long productId = savedProduct.getId();
-        productService.delete(productId);
-        assertThatThrownBy(() -> productService.getById(productId))
-                .isInstanceOf(ProductNotFoundException.class);
+    void createProduct_Success() {
+        CreateProductRequestDto createRequest = new CreateProductRequestDto();
+        createRequest.setName("새로운 상품");
+        createRequest.setPrice(20000);
+        createRequest.setImageUrl("new.jpg");
+        Product savedProduct = productService.create(createRequest);
+        Product foundProduct = productRepository.findById(savedProduct.getId()).orElseThrow();
+        assertThat(foundProduct.getName()).isEqualTo("새로운 상품");
+        assertThat(foundProduct.getPrice()).isEqualTo(20000);
     }
 
     @Test
     void deleteNonExistentProduct() {
-        Long nonExistentId = 99999L;
-        assertThatThrownBy(() -> productService.delete(nonExistentId))
+        Long nonExistentId = 9999L;
+        productService.delete(nonExistentId);
+        assertThat(productRepository.findById(nonExistentId)).isEmpty();
+    }
+
+    @Test
+    void getProductById_NotFound() {
+        Long nonExistentId = 9999L;
+        assertThatThrownBy(() -> productService.getById(nonExistentId))
                 .isInstanceOf(ProductNotFoundException.class);
     }
+
 }

--- a/src/test/java/gift/service/WishServiceTest.java
+++ b/src/test/java/gift/service/WishServiceTest.java
@@ -107,17 +107,17 @@ public class WishServiceTest {
     @Test
     void deleteWish_success() {
         Long wishId = 1L;
-        given(wishRepository.deleteByIdAndMember_Id(wishId, member.getId())).willReturn(1);
+        given(wishRepository.deleteByIdAndMemberId(wishId, member.getId())).willReturn(1);
 
         wishService.deleteWish(wishId, member);
 
-        verify(wishRepository).deleteByIdAndMember_Id(wishId, member.getId());
+        verify(wishRepository).deleteByIdAndMemberId(wishId, member.getId());
     }
 
     @Test
     void deleteWish_fail_unauthorized() {
         Long wishId = 1L;
-        given(wishRepository.deleteByIdAndMember_Id(wishId, member.getId())).willReturn(0);
+        given(wishRepository.deleteByIdAndMemberId(wishId, member.getId())).willReturn(0);
 
         assertThatThrownBy(() -> wishService.deleteWish(wishId, member))
                 .isInstanceOf(UnauthorizedWishAccessException.class);

--- a/src/test/java/gift/service/WishServiceTest.java
+++ b/src/test/java/gift/service/WishServiceTest.java
@@ -13,9 +13,11 @@ import gift.repository.WishRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.List;
 import java.util.Optional;
@@ -45,41 +47,59 @@ public class WishServiceTest {
 
     @BeforeEach
     void setUp() {
-        member = new Member(1L, "test@test.com", "password");
-        product = new Product(100L, "테스트 상품", 10000, "test.jpg");
+        member = new Member("test@test.com", "password");
+        ReflectionTestUtils.setField(member, "id", 1L);
+
+        product = new Product("테스트 상품", 10000, "test.jpg");
+        ReflectionTestUtils.setField(product, "id", 100L);
+
         wishRequestDto = new WishRequestDto();
         wishRequestDto.setProductId(product.getId());
     }
 
     @Test
     void addWish_success() {
-        given(productRepository.findById(product.getId())).willReturn(Optional.of(product));
-        given(wishRepository.findByMemberIdAndProductId(member.getId(), product.getId())).willReturn(Optional.empty());
+        given(productRepository.findById(any(Long.class))).willReturn(Optional.of(product));
+        given(wishRepository.findByMemberAndProduct(member, product)).willReturn(Optional.empty());
+        given(wishRepository.save(any(Wish.class))).willReturn(new Wish(member, product));
+
         wishService.addWish(member, wishRequestDto);
-        verify(wishRepository).save(any(Wish.class));
+
+        ArgumentCaptor<Wish> wishCaptor = ArgumentCaptor.forClass(Wish.class);
+        verify(wishRepository).save(wishCaptor.capture());
+
+        Wish savedWish = wishCaptor.getValue();
+        assertThat(savedWish.getMember()).isEqualTo(member);
+        assertThat(savedWish.getProduct()).isEqualTo(product);
     }
 
     @Test
     void addWish_fail_productNotFound() {
-        given(productRepository.findById(product.getId())).willReturn(Optional.empty());
+        given(productRepository.findById(any(Long.class))).willReturn(Optional.empty());
+
         assertThatThrownBy(() -> wishService.addWish(member, wishRequestDto))
                 .isInstanceOf(ProductNotFoundException.class);
+
         verify(wishRepository, never()).save(any(Wish.class));
     }
 
     @Test
     void addWish_fail_alreadyExists() {
-        given(productRepository.findById(product.getId())).willReturn(Optional.of(product));
-        given(wishRepository.findByMemberIdAndProductId(member.getId(), product.getId())).willReturn(Optional.of(new Wish(1L, member.getId(), product.getId())));
+        given(productRepository.findById(any(Long.class))).willReturn(Optional.of(product));
+        given(wishRepository.findByMemberAndProduct(member, product))
+                .willReturn(Optional.of(new Wish(member, product)));
+
         assertThatThrownBy(() -> wishService.addWish(member, wishRequestDto))
                 .isInstanceOf(WishAlreadyExistsException.class);
     }
 
     @Test
     void getWishes_success() {
-        WishResponseDto wishDto = new WishResponseDto(1L, product.getId(), product.getName(), product.getPrice(), product.getImageUrl());
-        given(wishRepository.findWishesWithProductByMemberId(member.getId())).willReturn(List.of(wishDto));
+        WishResponseDto wishDto = new WishResponseDto(1L, 100L, "테스트 상품", 10000, "test.jpg");
+        given(wishRepository.findWithProductByMember_Id(any(Long.class))).willReturn(List.of(wishDto));
+
         List<WishResponseDto> result = wishService.getWishesByMember(member);
+
         assertThat(result).hasSize(1);
         assertThat(result.get(0).productName()).isEqualTo("테스트 상품");
     }
@@ -87,15 +107,17 @@ public class WishServiceTest {
     @Test
     void deleteWish_success() {
         Long wishId = 1L;
-        given(wishRepository.deleteByIdAndMemberId(wishId, member.getId())).willReturn(1);
+        given(wishRepository.deleteByIdAndMember_Id(wishId, member.getId())).willReturn(1);
+
         wishService.deleteWish(wishId, member);
-        verify(wishRepository).deleteByIdAndMemberId(wishId, member.getId());
+
+        verify(wishRepository).deleteByIdAndMember_Id(wishId, member.getId());
     }
 
     @Test
     void deleteWish_fail_unauthorized() {
         Long wishId = 1L;
-        given(wishRepository.deleteByIdAndMemberId(wishId, member.getId())).willReturn(0); // 삭제된 행이 없음
+        given(wishRepository.deleteByIdAndMember_Id(wishId, member.getId())).willReturn(0);
 
         assertThatThrownBy(() -> wishService.deleteWish(wishId, member))
                 .isInstanceOf(UnauthorizedWishAccessException.class);

--- a/src/test/java/gift/validation/ProductNameValidatorTest.java
+++ b/src/test/java/gift/validation/ProductNameValidatorTest.java
@@ -1,6 +1,5 @@
 package gift.validation;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import jakarta.validation.ConstraintValidatorContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -8,55 +7,52 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mockito;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 public class ProductNameValidatorTest {
     private ProductNameValidator validator;
     private ConstraintValidatorContext context;
 
     @BeforeEach
-    void setUp()
-    {
+    void setUp() {
         validator = new ProductNameValidator();
         context = Mockito.mock(ConstraintValidatorContext.class);
-        ConstraintValidatorContext.ConstraintViolationBuilder builder= Mockito.mock(ConstraintValidatorContext.ConstraintViolationBuilder.class);
+        ConstraintValidatorContext.ConstraintViolationBuilder builder = Mockito.mock(ConstraintValidatorContext.ConstraintViolationBuilder.class);
         Mockito.when(context.buildConstraintViolationWithTemplate(Mockito.anyString())).thenReturn(builder);
     }
 
     @Test
-    void testValidProductName()
-    {
-        String validName="상품(123)";
-        boolean result=validator.isValid(validName, context);
+    void testValidProductName() {
+        String validName = "상품(123)";
+        boolean result = validator.isValid(validName, context);
         assertThat(result).isTrue();
     }
 
     @Test
-    void testNameLengthExceeded()
-    {
-        String longName="이 상품의 이름은 15자를 훌쩍 넘습니다.";
-        boolean result=validator.isValid(longName, context);
+    void testNameLengthExceeded() {
+        String longName = "이 상품의 이름은 15자를 훌쩍 넘습니다.";
+        boolean result = validator.isValid(longName, context);
         assertThat(result).isFalse();
     }
 
     @Test
-    void testNameMaxLength()
-    {
-        String maxName="123456789012345";
-        boolean result=validator.isValid(maxName, context);
+    void testNameMaxLength() {
+        String maxName = "123456789012345";
+        boolean result = validator.isValid(maxName, context);
         assertThat(result).isTrue();
     }
 
     @Test
-    void testForbiddenWordKaKao()
-    {
-        String forbiddenName="카카오프렌즈";
-        boolean result=validator.isValid(forbiddenName, context);
+    void testForbiddenWordKaKao() {
+        String forbiddenName = "카카오프렌즈";
+        boolean result = validator.isValid(forbiddenName, context);
         assertThat(result).isFalse();
     }
+
     @ParameterizedTest
     @ValueSource(strings = {"상품!", "상품#", "상품$", "상품*"})
-    void testInvalidCharacters(String invalidName)
-    {
-        boolean result=validator.isValid(invalidName, context);
+    void testInvalidCharacters(String invalidName) {
+        boolean result = validator.isValid(invalidName, context);
         assertThat(result).isFalse();
     }
 

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -1,0 +1,8 @@
+spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1
+spring.datasource.driver-class-name=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.jpa.hibernate.ddl-auto=create-drop
+spring.sql.init.mode=never
+security.jwt.token.secret-key=test-super-secret-key-for-jwt-token-generation-54321
+security.jwt.token.expire-length=3600000

--- a/src/test/resources/cleanup.sql
+++ b/src/test/resources/cleanup.sql
@@ -1,1 +1,2 @@
-Delete from member;
+Delete
+from member;

--- a/src/test/resources/test-data.sql
+++ b/src/test/resources/test-data.sql
@@ -1,9 +1,17 @@
-DELETE FROM wish;
-DELETE FROM products;
-DELETE FROM member;
+DELETE
+FROM wish;
+DELETE
+FROM products;
+DELETE
+FROM member;
 
-INSERT INTO member (id, email, password) VALUES (1, 'userA@example.com', 'hashed_password');
-INSERT INTO member (id, email, password) VALUES (2, 'userB@example.com', 'hashed_password');
-INSERT INTO products (id, name, price, image_url) VALUES (101, '상품A', 1000, 'urlA');
-INSERT INTO products (id, name, price, image_url) VALUES (102, '상품B', 2000, 'urlB');
-INSERT INTO wish (id, member_id, product_id) VALUES (1001, 1, 101);
+INSERT INTO member (id, email, password)
+VALUES (1, 'userA@example.com', 'hashed_password');
+INSERT INTO member (id, email, password)
+VALUES (2, 'userB@example.com', 'hashed_password');
+INSERT INTO products (id, name, price, image_url)
+VALUES (101, '상품A', 1000, 'urlA');
+INSERT INTO products (id, name, price, image_url)
+VALUES (102, '상품B', 2000, 'urlB');
+INSERT INTO wish (id, member_id, product_id)
+VALUES (1001, 1, 101);


### PR DESCRIPTION
안녕하십니까, 멘토님

이전 미션이었던 JdbcTemplate 기반 코드를 Spring Data JPA로 전환하는 리팩터링을 완료했습니다. 객체지향적인 설계와 JPA의 특징을 최대한 활용하려고 노력했습니다.

우선 Repository계층을 JPARepository 인터페이스로 전환했습니다.
그리고 엔티티 설계의 경우 엔티티 간에 직접 객체 참조를 사용하도록 연관관계를 매핑했습니다.

서비스 계층에서는 @Transactional 환경에서 엔티티를 조회하고 상태를 변경하기만 하면 자동으로 update 쿼리가 실행되는 dirty checking을 적용해보고자 했습니다.

그리고 @DataJpaTest를 사용해보라는 강의 자료를 토대로 테스트 코드를 구현해보았습니다.

그리고 지난 멘토님께도 받았던 테스트 코드 일부분의 실패 케이스에 대해서는 JPA로 전환했더니 gradlew clean test 해본 결과 Build Successful이 뜨는 것을 확인하였는데 한번 더 확인 부탁 드립니다.

제가 놓친 부분이나 개선할 사항들을 알려주시면 큰 도움이 될 것 같습니다.

감사합니다.