### PR TITLE
부산대 BE_오선재 Step1 - 엔티티 매핑

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,77 @@
 # spring-gift-enhancement
+
+### Spring-gift-product README.md - https://github.com/5seonjae/spring-gift-product/blob/step3/README.md
+
+### Spring-gift-wishlist README.md - https://github.com/5seonjae/spring-gift-wishlist/blob/step3/README.md
+
+---
+
+## 🚀 Step 1 – 엔티티 매핑
+
+### 🎯 기능 요구사항 체크리스트
+
+- [ ] **DDL 검토 & Migration**
+    - 기존 테이블 스키마(MySQL / H2) 확인
+    - `members`, `products`, `wish`, `approved_product` 테이블에 필요한 컬럼·제약조건 추가/수정 스크립트 작성
+- [ ] **Entity 클래스 작성**
+    - `Member`, `Product`, `Wish`, (`ApprovedProduct`) 엔티티 생성
+    - JPA 어노테이션으로 컬럼·PK·외래키 매핑
+    - 양방향 관계 매핑 시 `mappedBy`, `cascade`, `orphanRemoval` 설정
+- [ ] **Repository 인터페이스 정의**
+    - `MemberRepository extends JpaRepository<Member,Long>`
+    - `ProductRepository`, `WishRepository`, `ApprovedProductRepository` 등
+    - 커스텀 조회 메서드 선언(ex. `List<Wish> findAllByMemberId(Long)` )
+- [ ] **application.yml(또는 .properties) 설정**
+    - MySQL + H2(test) 데이터소스 분리
+    - `spring.jpa.show-sql=true`
+    - `spring.jpa.properties.hibernate.format_sql=true`
+    - 테스트 시 `ddl-auto: create-drop`, 운영 시 `ddl-auto: none`
+- [ ] **Service 레이어 리팩터링**
+    - 기존 `JdbcClient` 구현체 → JPA Repository 주입으로 전환
+    - 회원가입·로그인·상품등록·찜목록 기능 흐름 점검
+- [ ] **학습 테스트 작성**
+    - `@DataJpaTest`로 각 Repository의 save/find 동작 검증
+- [ ] **불필요한 JdbcClient 코드 정리**
+    - 마이그레이션 완료 후 보조 패키지로 이동 또는 삭제 
+
+### 📐 DDL (MySQL 예시)
+
+```sql
+CREATE TABLE products
+(
+id BIGINT PRIMARY KEY AUTO_INCREMENT,
+name VARCHAR(255) NOT NULL,
+price INT NOT NULL,
+image_url VARCHAR(255) NOT NULL
+);
+```
+```sql
+CREATE TABLE approved_products
+(
+id BIGINT AUTO_INCREMENT PRIMARY KEY,
+name VARCHAR(100) NOT NULL UNIQUE
+);
+```
+```sql
+CREATE TABLE members
+(
+id BIGINT PRIMARY KEY AUTO_INCREMENT,
+email VARCHAR(255) NOT NULL,
+password VARCHAR(255) NOT NULL,
+is_admin BOOLEAN NOT NULL DEFAULT FALSE
+);
+```
+```sql
+CREATE TABLE wish_items
+(
+id BIGINT PRIMARY KEY AUTO_INCREMENT,
+member_id BIGINT NOT NULL,
+product_id BIGINT NOT NULL,
+quantity INT NOT NULL DEFAULT 1,
+CONSTRAINT uk_member_product UNIQUE (member_id, product_id),
+CONSTRAINT fk_wish_member FOREIGN KEY (member_id) REFERENCES members(id),
+CONSTRAINT fk_wish_product FOREIGN KEY (product_id) REFERENCES products(id)
+);
+```
+
+---

--- a/README.md
+++ b/README.md
@@ -10,28 +10,28 @@
 
 ### 🎯 기능 요구사항 체크리스트
 
-- [ ] **DDL 검토 & Migration**
+- [x] **DDL 검토 & Migration**
     - 기존 테이블 스키마(MySQL / H2) 확인
     - `members`, `products`, `wish`, `approved_product` 테이블에 필요한 컬럼·제약조건 추가/수정 스크립트 작성
-- [ ] **Entity 클래스 작성**
+- [x] **Entity 클래스 작성**
     - `Member`, `Product`, `Wish`, (`ApprovedProduct`) 엔티티 생성
     - JPA 어노테이션으로 컬럼·PK·외래키 매핑
     - 양방향 관계 매핑 시 `mappedBy`, `cascade`, `orphanRemoval` 설정
-- [ ] **Repository 인터페이스 정의**
+- [x] **Repository 인터페이스 정의**
     - `MemberRepository extends JpaRepository<Member,Long>`
     - `ProductRepository`, `WishRepository`, `ApprovedProductRepository` 등
     - 커스텀 조회 메서드 선언(ex. `List<Wish> findAllByMemberId(Long)` )
-- [ ] **application.yml(또는 .properties) 설정**
+- [x] **application.yml(또는 .properties) 설정**
     - MySQL + H2(test) 데이터소스 분리
     - `spring.jpa.show-sql=true`
     - `spring.jpa.properties.hibernate.format_sql=true`
     - 테스트 시 `ddl-auto: create-drop`, 운영 시 `ddl-auto: none`
-- [ ] **Service 레이어 리팩터링**
+- [x] **Service 레이어 리팩터링**
     - 기존 `JdbcClient` 구현체 → JPA Repository 주입으로 전환
     - 회원가입·로그인·상품등록·찜목록 기능 흐름 점검
-- [ ] **학습 테스트 작성**
+- [x] **학습 테스트 작성**
     - `@DataJpaTest`로 각 Repository의 save/find 동작 검증
-- [ ] **불필요한 JdbcClient 코드 정리**
+- [x] **불필요한 JdbcClient 코드 정리**
     - 마이그레이션 완료 후 보조 패키지로 이동 또는 삭제 
 
 ### 📐 DDL (MySQL 예시)
@@ -40,7 +40,7 @@
 CREATE TABLE products
 (
 id BIGINT PRIMARY KEY AUTO_INCREMENT,
-name VARCHAR(255) NOT NULL,
+name VARCHAR(15) NOT NULL,
 price INT NOT NULL,
 image_url VARCHAR(255) NOT NULL
 );
@@ -56,7 +56,7 @@ name VARCHAR(100) NOT NULL UNIQUE
 CREATE TABLE members
 (
 id BIGINT PRIMARY KEY AUTO_INCREMENT,
-email VARCHAR(255) NOT NULL,
+email VARCHAR(255) NOT NULL UNIQUE,
 password VARCHAR(255) NOT NULL,
 is_admin BOOLEAN NOT NULL DEFAULT FALSE
 );

--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
     runtimeOnly  'io.jsonwebtoken:jjwt-impl:0.12.6'
     runtimeOnly  'io.jsonwebtoken:jjwt-jackson:0.12.6'

--- a/src/main/java/gift/auth/LoginMemberArgumentResolver.java
+++ b/src/main/java/gift/auth/LoginMemberArgumentResolver.java
@@ -5,12 +5,15 @@ import gift.repository.MemberRepository;
 import gift.service.TokenService;
 import gift.util.BearerAuthHeaderParser;
 import io.jsonwebtoken.Claims;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.core.MethodParameter;
 import org.springframework.stereotype.Component;
 import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
+import org.springframework.web.util.WebUtils;
 
 @Component
 public class LoginMemberArgumentResolver
@@ -19,13 +22,16 @@ public class LoginMemberArgumentResolver
     private final TokenService tokenService;
     private final MemberRepository memberRepository;
     private final BearerAuthHeaderParser authHeaderParser;
+    private final TokenExtractor tokenExtractor;
 
     public LoginMemberArgumentResolver(TokenService tokenService,
                                        MemberRepository memberRepository,
-                                       BearerAuthHeaderParser authHeaderParser) {
+                                       BearerAuthHeaderParser authHeaderParser,
+        TokenExtractor tokenExtractor) {
         this.tokenService = tokenService;
         this.memberRepository = memberRepository;
         this.authHeaderParser = authHeaderParser;
+        this.tokenExtractor = tokenExtractor;
     }
 
     @Override
@@ -36,15 +42,17 @@ public class LoginMemberArgumentResolver
 
     @Override
     public Object resolveArgument(MethodParameter parameter,
-                                  ModelAndViewContainer mavContainer,
-                                  NativeWebRequest webRequest,
-                                  WebDataBinderFactory binderFactory) {
-        String header = webRequest.getHeader("Authorization");
+        ModelAndViewContainer mavContainer,
+        NativeWebRequest webRequest,
+        WebDataBinderFactory binderFactory) {
+        HttpServletRequest r = webRequest.getNativeRequest(HttpServletRequest.class);
+
+        String header = tokenExtractor.extractBearerHeader(r);
         String token = authHeaderParser.extractBearerToken(header);
         Claims claims = tokenService.parseClaims(token);
         Long memberId = Long.valueOf(claims.getSubject());
 
         return memberRepository.findById(memberId)
-                .orElseThrow(() -> new IllegalStateException("존재하지 않는 회원입니다."));
+            .orElseThrow(() -> new IllegalStateException("존재하지 않는 회원입니다."));
     }
 }

--- a/src/main/java/gift/auth/TokenExtractor.java
+++ b/src/main/java/gift/auth/TokenExtractor.java
@@ -1,0 +1,21 @@
+package gift.auth;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.util.WebUtils;
+
+@Component
+public class TokenExtractor {
+
+    public String extractBearerHeader(HttpServletRequest req) {
+        String header = req.getHeader("Authorization");
+        if (header != null && header.startsWith("Bearer ")) return header;
+        Cookie cookie = WebUtils.getCookie(req, "AUTH");
+        if (cookie != null && StringUtils.hasText(cookie.getValue())) {
+            return "Bearer " + cookie.getValue();
+        }
+        return null;
+    }
+}

--- a/src/main/java/gift/dto/api/WishResponseDto.java
+++ b/src/main/java/gift/dto/api/WishResponseDto.java
@@ -32,10 +32,10 @@ public record WishResponseDto(
 
     public static WishResponseDto of(WishItem wi) {
         return new WishResponseDto(
-            wi.getProductId(),
-            wi.getProductName(),
-            wi.getPrice(),
-            wi.getImageUrl(),
+            wi.getProduct().getId(),
+            wi.getProduct().getName(),
+            wi.getProduct().getPrice(),
+            wi.getProduct().getImageUrl(),
             wi.getQuantity()
         );
     }

--- a/src/main/java/gift/entity/ApprovedProduct.java
+++ b/src/main/java/gift/entity/ApprovedProduct.java
@@ -1,8 +1,21 @@
 package gift.entity;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "approved_products")
 public class ApprovedProduct {
 
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @Column(nullable = false, unique = true)
     private String name;
 
     public ApprovedProduct() {

--- a/src/main/java/gift/entity/ApprovedProduct.java
+++ b/src/main/java/gift/entity/ApprovedProduct.java
@@ -18,7 +18,7 @@ public class ApprovedProduct {
     @Column(nullable = false, unique = true)
     private String name;
 
-    public ApprovedProduct() {
+    protected ApprovedProduct() {
     }
 
     public ApprovedProduct(String name) {

--- a/src/main/java/gift/entity/Member.java
+++ b/src/main/java/gift/entity/Member.java
@@ -39,7 +39,7 @@ public class Member {
         this.password = password;
     }
 
-    public Member() {}
+    protected Member() {}
 
     public Member(String email, String password) {
         this(null, email, password);

--- a/src/main/java/gift/entity/Member.java
+++ b/src/main/java/gift/entity/Member.java
@@ -1,12 +1,35 @@
 package gift.entity;
 
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "members")
 public class Member {
 
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(nullable = false, unique = true)
     private String email;
 
+    @Column(nullable = false)
     private String password;
+
+    @Column(name = "is_admin", nullable = false)
+    private boolean isAdmin = false;
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<WishItem> wishItems = new ArrayList<>();
 
     public Member(Long id, String email, String password) {
         validate(email, password);
@@ -15,6 +38,8 @@ public class Member {
         this.email = email;
         this.password = password;
     }
+
+    public Member() {}
 
     public Member(String email, String password) {
         this(null, email, password);
@@ -50,5 +75,9 @@ public class Member {
 
     public String getPassword() {
         return password;
+    }
+
+    public boolean getIsAdmin() {
+        return isAdmin;
     }
 }

--- a/src/main/java/gift/entity/Product.java
+++ b/src/main/java/gift/entity/Product.java
@@ -1,16 +1,29 @@
 package gift.entity;
 
-import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import jakarta.persistence.*;
 
-@JsonPropertyOrder({"id", "name", "price", "imageUrl"})
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "products")
 public class Product {
 
-    // DB에서 자동 생성되는 ID는 등록 시점에는 null일 수 있으므로 Long 사용
-    // 또한 Product는 불변 객체이므로 생성자에서만 값을 설정할 수 있도록 설계
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @Column(nullable = false, length = 15)
     private String name;
+
+    @Column(nullable = false)
     private int price;
+
+    @Column(name = "image_url", nullable = false)
     private String imageUrl;
+
+    @OneToMany(mappedBy = "product", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<WishItem> wishItems = new ArrayList<>();
 
     public Product() {
     }

--- a/src/main/java/gift/entity/Product.java
+++ b/src/main/java/gift/entity/Product.java
@@ -25,7 +25,7 @@ public class Product {
     @OneToMany(mappedBy = "product", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<WishItem> wishItems = new ArrayList<>();
 
-    public Product() {
+    protected Product() {
     }
 
     /**

--- a/src/main/java/gift/entity/WishItem.java
+++ b/src/main/java/gift/entity/WishItem.java
@@ -1,49 +1,62 @@
 package gift.entity;
 
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "wish_items")
 public class WishItem {
 
-    private final Long memberId;
-    private final Long productId;
-    private final String productName;
-    private final int price;
-    private final String imageUrl;
-    private final int quantity;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
 
-    public WishItem(Long memberId,
-                    Long productId,
-                    String productName,
-                    int price,
-                    String imageUrl,
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "product_id")
+    private Product product;
+
+    @Column(nullable = false)
+    private int quantity;
+
+    public WishItem() {
+    }
+
+    public WishItem(Long id,
+                    Member member,
+                    Product product,
                     int quantity) {
-        this.memberId = memberId;
-        this.productId = productId;
-        this.productName = productName;
-        this.price = price;
-        this.imageUrl = imageUrl;
+        this.id = id;
+        this.member = member;
+        this.product = product;
         this.quantity = quantity;
     }
 
-    public Long getMemberId() {
-        return memberId;
+    public WishItem(Member member,
+                    Product product,
+                    int quantity) {
+        this(null, member, product, quantity);
     }
 
-    public Long getProductId() {
-        return productId;
+    public Long getId() {
+        return id;
     }
 
-    public String getProductName() {
-        return productName;
+    public Member getMember() {
+        return member;
     }
 
-    public int getPrice() {
-        return price;
-    }
-
-    public String getImageUrl() {
-        return imageUrl;
+    public Product getProduct() {
+        return product;
     }
 
     public int getQuantity() {
         return quantity;
+    }
+
+    public void addQuantity(Integer quantity) {
+        this.quantity += quantity;
     }
 }

--- a/src/main/java/gift/entity/WishItem.java
+++ b/src/main/java/gift/entity/WishItem.java
@@ -21,7 +21,7 @@ public class WishItem {
     @Column(nullable = false)
     private int quantity;
 
-    public WishItem() {
+    protected WishItem() {
     }
 
     public WishItem(Long id,

--- a/src/main/java/gift/repository/ApprovedProductRepository.java
+++ b/src/main/java/gift/repository/ApprovedProductRepository.java
@@ -1,31 +1,13 @@
 package gift.repository;
 
 import gift.entity.ApprovedProduct;
+import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.jdbc.core.simple.JdbcClient;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public class ApprovedProductRepository {
-
-    private final JdbcClient jdbcClient;
-
-    public ApprovedProductRepository(JdbcClient jdbcClient) {
-        this.jdbcClient = jdbcClient;
-    }
+public interface ApprovedProductRepository extends JpaRepository<ApprovedProduct, Long> {
 
     // 승인 여부 확인
-    public boolean isApproved(String name) {
-        String sql = "SELECT EXISTS (SELECT 1 FROM approved_products WHERE name = ?)";
-        return jdbcClient
-            .sql(sql)
-            .param(name)
-            .query(Boolean.class)
-            .single();
-    }
-
-    // 승인 상품 등록
-    public void save(ApprovedProduct product) {
-        String sql = "INSERT INTO approved_products (name) VALUES (?)";
-        jdbcClient.sql(sql).param(product.getName()).update();
-    }
+    boolean existsByName(String name);
 }

--- a/src/main/java/gift/repository/ApprovedProductRepository.java
+++ b/src/main/java/gift/repository/ApprovedProductRepository.java
@@ -2,7 +2,6 @@ package gift.repository;
 
 import gift.entity.ApprovedProduct;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.jdbc.core.simple.JdbcClient;
 import org.springframework.stereotype.Repository;
 
 @Repository

--- a/src/main/java/gift/repository/MemberRepository.java
+++ b/src/main/java/gift/repository/MemberRepository.java
@@ -1,78 +1,15 @@
 package gift.repository;
 
 import gift.entity.Member;
-import java.sql.ResultSet;
-import java.sql.SQLException;
 import java.util.Optional;
-import org.springframework.jdbc.core.simple.JdbcClient;
-import org.springframework.jdbc.support.GeneratedKeyHolder;
-import org.springframework.jdbc.support.KeyHolder;
+
+import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public class MemberRepository {
+public interface MemberRepository extends JpaRepository<Member, Long> {
 
-    private final JdbcClient jdbcClient;
+    boolean existsByEmail(String email);
 
-    public MemberRepository(JdbcClient jdbcClient) {
-        this.jdbcClient = jdbcClient;
-    }
-
-    // 회원 저장
-    public Member save(Member member) {
-        String sql = "INSERT INTO members (email, password) VALUES (?, ?)";
-        KeyHolder keyHolder = new GeneratedKeyHolder();
-        jdbcClient
-            .sql(sql)
-            .param(member.getEmail())
-            .param(member.getPassword())
-            .update(keyHolder, "id");
-
-        Long id = keyHolder.getKey().longValue();
-        return new Member(id, member.getEmail(), member.getPassword());
-    }
-
-    public boolean existByEmail(String email) {
-        String sql = "SELECT EXISTS (SELECT 1 FROM members WHERE email = ?)";
-        return jdbcClient
-            .sql(sql)
-            .param(email)
-            .query(Boolean.class)
-            .single();
-    }
-
-    private Member mapRowToMember(ResultSet rs, int rowNum) throws SQLException {
-        return new Member(
-            rs.getLong("id"),
-            rs.getString("email"),
-            rs.getString("password")
-        );
-    }
-
-    public Optional<Member> findById(Long id) {
-        String sql = "SELECT id, email, password FROM members WHERE id = ?";
-        return jdbcClient
-            .sql(sql)
-            .param(id)
-            .query(this::mapRowToMember)
-            .optional();
-    }
-
-    public Optional<Member> findByEmail(String email) {
-        String sql = "SELECT id, email, password FROM members WHERE email = ?";
-        return jdbcClient
-            .sql(sql)
-            .param(email)
-            .query(this::mapRowToMember)
-            .optional();
-    }
-
-    public boolean isAdminMember(Member member) {
-        String sql = "SELECT is_admin FROM members WHERE email = ?";
-        return jdbcClient
-            .sql(sql)
-            .param(member.getEmail())
-            .query(Boolean.class)
-            .single();
-    }
+    Optional<Member> findByEmail(String email);
 }

--- a/src/main/java/gift/repository/ProductRepository.java
+++ b/src/main/java/gift/repository/ProductRepository.java
@@ -1,90 +1,10 @@
 package gift.repository;
 
 import gift.entity.Product;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import org.springframework.jdbc.core.simple.JdbcClient;
-import org.springframework.jdbc.support.GeneratedKeyHolder;
-import org.springframework.jdbc.support.KeyHolder;
+
+import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
-import java.util.Optional;
-
 @Repository
-public class ProductRepository {
-
-    private final JdbcClient jdbcClient;
-
-    public ProductRepository(JdbcClient jdbcClient) {
-        this.jdbcClient = jdbcClient;
-    }
-
-    public Product save(Product product) {
-        String sql = "INSERT INTO products (name, price, image_url) VALUES (?, ?, ?)";
-        KeyHolder keyHolder = new GeneratedKeyHolder();
-        jdbcClient
-            .sql(sql)
-            .param(product.getName())
-            .param(product.getPrice())
-            .param(product.getImageUrl())
-            .update(keyHolder, "id");
-
-        Long id = keyHolder.getKey().longValue();
-        return new Product(id, product.getName(), product.getPrice(), product.getImageUrl());
-    }
-
-    private Product mapRowToProduct(ResultSet rs, int rowNum) throws SQLException {
-        Product product = new Product(
-            rs.getLong("id"),
-            rs.getString("name"),
-            rs.getInt("price"),
-            rs.getString("image_url")
-        );
-        return product;
-    }
-
-    public List<Product> findAll() {
-        String sql = "SELECT * FROM products";
-        return jdbcClient
-            .sql(sql)
-            .query(this::mapRowToProduct)
-            .list();
-    }
-
-    public Optional<Product> findById(Long id) {
-        String sql = "SELECT * FROM products WHERE id = ?";
-        List<Product> result = jdbcClient
-            .sql(sql)
-            .param(id)
-            .query(this::mapRowToProduct)
-            .list();
-        return result.stream().findFirst();
-    }
-
-    public void update(Product product) {
-        String sql = "UPDATE products SET name = ?, price = ?, image_url = ? WHERE id = ?";
-        jdbcClient
-            .sql(sql)
-            .param(product.getName())
-            .param(product.getPrice())
-            .param(product.getImageUrl())
-            .param(product.getId())
-            .update();
-    }
-
-    public void delete(Long id) {
-        String sql = "DELETE FROM products WHERE id = ?";
-        jdbcClient
-            .sql(sql)
-            .param(id)
-            .update();
-    }
-
-    public void deleteAll() {
-        String sql = "DELETE FROM products";
-        jdbcClient
-            .sql(sql)
-            .update();
-    }
+public interface ProductRepository extends JpaRepository<Product, Long> {
 }

--- a/src/main/java/gift/repository/WishRepository.java
+++ b/src/main/java/gift/repository/WishRepository.java
@@ -1,67 +1,15 @@
 package gift.repository;
 
 import gift.entity.WishItem;
-import org.springframework.jdbc.core.simple.JdbcClient;
+import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import java.sql.ResultSet;
-import java.sql.SQLException;
 import java.util.List;
 
 @Repository
-public class WishRepository {
+public interface WishRepository extends JpaRepository<WishItem, Long> {
 
-    private final JdbcClient jdbcClient;
+    List<WishItem> findAllByMemberId(Long memberId);
 
-    public WishRepository(JdbcClient jdbcClient) {
-        this.jdbcClient = jdbcClient;
-    }
-
-    private WishItem mapRowToWishItem(ResultSet rs, int rowNum) throws SQLException {
-        return new WishItem(
-            rs.getLong("member_id"),
-            rs.getLong("product_id"),
-            rs.getString("name"),
-            rs.getInt("price"),
-            rs.getString("image_url"),
-            rs.getInt("quantity")
-        );
-    }
-
-    public List<WishItem> findAllByMemberId(Long memberId) {
-        String sql = """
-            SELECT wi.member_id, wi.product_id, p.name, p.price, p.image_url, wi.quantity 
-            FROM wish_items AS wi 
-            JOIN products AS p
-            ON wi.product_id = p.id
-            WHERE wi.member_id = ?
-            """;
-        return jdbcClient.sql(sql)
-            .param(memberId)
-            .query(this::mapRowToWishItem)
-            .list();
-    }
-
-    public void updateOrInsertWishItem(Long memberId, Long productId, int quantity) {
-        String sql = """
-            INSERT INTO wish_items (member_id, product_id, quantity)
-            VALUES (?, ?, ?)
-            ON DUPLICATE KEY UPDATE
-            quantity = wish_items.quantity + ?
-            """;
-        jdbcClient.sql(sql)
-            .param(memberId)
-            .param(productId)
-            .param(quantity)
-            .param(quantity)
-            .update();
-    }
-
-    public int delete(Long memberId, Long productId) {
-        String sql = "DELETE FROM wish_items WHERE member_id = ? AND product_id = ?";
-        return jdbcClient.sql(sql)
-            .param(memberId)
-            .param(productId)
-            .update();        // update() 가 영향 행 수를 리턴
-    }
+    int deleteByMemberIdAndProductId(Long memberId, Long productId);
 }

--- a/src/main/java/gift/service/MemberService.java
+++ b/src/main/java/gift/service/MemberService.java
@@ -22,7 +22,7 @@ public class MemberService {
     // 회원 등록
     public String registerMember(MemberRegisterRequestDto requestDto) {
         // 이메일 중복 검사
-        if (memberRepository.existByEmail(requestDto.getEmail())) {
+        if (memberRepository.existsByEmail(requestDto.getEmail())) {
             throw new DuplicateKeyException("이미 사용 중인 이메일입니다.");
         }
 
@@ -48,6 +48,6 @@ public class MemberService {
         Member member = memberRepository.findByEmail(email)
             .orElseThrow(() -> new InvalidCredentialsException("이메일 또는 비밀번호가 올바르지 않습니다."));
 
-        return memberRepository.isAdminMember(member);
+        return member.getIsAdmin();
     }
 }

--- a/src/main/java/gift/service/ProductService.java
+++ b/src/main/java/gift/service/ProductService.java
@@ -49,7 +49,7 @@ public class ProductService {
 
         // '카카오' 문구 검증
         verifyKakaoNameIsApproved(updated.getName());
-        repository.update(updated);
+        repository.save(updated);
         return updated;  // 또는 existing → 필요에 따라 선택 가능
     }
 
@@ -57,7 +57,7 @@ public class ProductService {
         if (repository.findById(id).isEmpty()) {
             throw new NoSuchElementException("상품을 찾을 수 없습니다.");
         }
-        repository.delete(id);
+        repository.deleteById(id);
     }
 
     // "카카오" 문구 검증 로직 공통 메서드

--- a/src/main/java/gift/service/ProductService.java
+++ b/src/main/java/gift/service/ProductService.java
@@ -63,7 +63,7 @@ public class ProductService {
     // "카카오" 문구 검증 로직 공통 메서드
     private void verifyKakaoNameIsApproved(String name) {
         if (name.contains("카카오")) {
-            if (!approvedRepository.isApproved(name)) {
+            if (!approvedRepository.existsByName(name)) {
                 throw new IllegalArgumentException("'카카오'가 포함된 상품은 MD 승인이 필요합니다.");
             }
         }

--- a/src/main/java/gift/service/WishService.java
+++ b/src/main/java/gift/service/WishService.java
@@ -3,12 +3,14 @@ package gift.service;
 import gift.dto.api.WishRequestDto;
 import gift.dto.api.WishResponseDto;
 import gift.entity.Member;
+import gift.entity.Product;
 import gift.entity.WishItem;
 import gift.exception.InvalidMemberException;
 import gift.repository.ProductRepository;
 import gift.repository.WishRepository;
 import org.springframework.stereotype.Service;
 
+import java.util.Objects;
 import java.util.List;
 import java.util.NoSuchElementException;
 
@@ -34,15 +36,17 @@ public class WishService {
 
     public void addWishItemForMember(Member member, WishRequestDto wishRequestDto) {
         validateMember(member);
-        if (productRepository.findById(wishRequestDto.productId()).isEmpty()) {
-            throw new NoSuchElementException("상품을 찾을 수 없습니다.");
-        }
 
-        wishRepository.updateOrInsertWishItem(
-            member.getId(),
-            wishRequestDto.productId(),
-            wishRequestDto.quantity()
-        );
+        Product product = productRepository.findById(wishRequestDto.productId()).orElseThrow(
+                () -> new NoSuchElementException("상품을 찾을 수 없습니다."));
+
+        wishRepository.findAllByMemberId(member.getId()).stream()
+                .filter(w -> Objects.equals(w.getProduct().getId(), wishRequestDto.productId()))
+                .findFirst()
+                .ifPresentOrElse(
+                        w -> { w.addQuantity(wishRequestDto.quantity()); },
+                        () -> { wishRepository.save(new WishItem(member, product, wishRequestDto.quantity())); }
+                );
     }
 
     public void removeWishItemForMember(Member member, Long productId) {
@@ -51,7 +55,7 @@ public class WishService {
             throw new NoSuchElementException("상품을 찾을 수 없습니다.");
         }
 
-        int rows = wishRepository.delete(member.getId(), productId);
+        int rows = wishRepository.deleteByMemberIdAndProductId(member.getId(), productId);
 
         if (rows == 0) {                               // ← 위시 항목 없었음
             throw new NoSuchElementException("위시 목록에 없는 상품입니다.");

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,6 +6,7 @@ spring.application.name=spring-gift
 spring.datasource.url=jdbc:h2:mem:testdb;MODE=MySQL;DB_CLOSE_DELAY=-1
 spring.datasource.username=sa
 spring.datasource.password=
+spring.jpa.database-platform=org.hibernate.dialect.MySQLDialect
 
 # SQL 스크립트 자동 실행 설정
 spring.sql.init.mode=always
@@ -13,3 +14,6 @@ spring.sql.init.mode=always
 # H2 콘솔 설정
 spring.h2.console.enabled=true
 spring.h2.console.path=/h2-console
+
+spring.jpa.properties.hibernate.format_sql=true
+spring.jpa.show-sql=true

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,10 +6,10 @@ spring.application.name=spring-gift
 spring.datasource.url=jdbc:h2:mem:testdb;MODE=MySQL;DB_CLOSE_DELAY=-1
 spring.datasource.username=sa
 spring.datasource.password=
-spring.jpa.database-platform=org.hibernate.dialect.MySQLDialect
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
 
 # SQL 스크립트 자동 실행 설정
-spring.sql.init.mode=always
+spring.sql.init.mode=never
 
 # H2 콘솔 설정
 spring.h2.console.enabled=true
@@ -17,3 +17,4 @@ spring.h2.console.path=/h2-console
 
 spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.show-sql=true
+spring.jpa.hibernate.ddl-auto=create

--- a/src/main/resources/import.sql
+++ b/src/main/resources/import.sql
@@ -1,0 +1,8 @@
+INSERT INTO products (name, price, image_url) VALUES ('초콜릿', 1000, 'http://localhost:8080/image/chocolate.webp');
+INSERT INTO products (name, price, image_url) VALUES ('새우깡', 1500, 'http://localhost:8080/image/shrimpCrackers.webp');
+
+INSERT INTO approved_products (name) VALUES ('카카오 프렌즈 필통');
+INSERT INTO approved_products (name) VALUES ('카카오 프렌즈 인형');
+
+INSERT INTO members (email, password, is_admin) VALUES ('5seonjae@gmail.com', '5seonjae', true);
+INSERT INTO members (email, password, is_admin) VALUES ('6seonjae@gmail.com', '6seonjae', false);

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,7 +1,7 @@
 CREATE TABLE products
 (
     id BIGINT PRIMARY KEY AUTO_INCREMENT,
-    name VARCHAR(255) NOT NULL,
+    name VARCHAR(15) NOT NULL,
     price INT NOT NULL,
     image_url VARCHAR(255) NOT NULL
 );
@@ -16,7 +16,7 @@ CREATE TABLE approved_products
 CREATE TABLE members
 (
     id BIGINT PRIMARY KEY AUTO_INCREMENT,
-    email VARCHAR(255) NOT NULL,
+    email VARCHAR(255) NOT NULL UNIQUE,
     password VARCHAR(255) NOT NULL,
     is_admin BOOLEAN NOT NULL DEFAULT FALSE
 );

--- a/src/main/resources/templates/products/admin/list.html
+++ b/src/main/resources/templates/products/admin/list.html
@@ -44,10 +44,6 @@
               style="display:inline;">
           <button type="submit" style="border:none; background:none;" title="삭제">🗑️</button>
         </form>
-        <!-- 🆕 Wish 추가 폼 -->
-        <form th:action="@{|/wishes/${product.id}|}" method="post" style="display:inline">
-          <button type="submit">🤍 찜</button>
-        </form>
       </td>
     </tr>
     </tbody>
@@ -56,4 +52,5 @@
 
 </body>
 </html>
+
 

--- a/src/main/resources/templates/products/user/list.html
+++ b/src/main/resources/templates/products/user/list.html
@@ -34,13 +34,17 @@
       <td><a th:href="@{'/products/' + ${product.id}}">상세보기</a></td>
       <td class="actions">
         <!-- 🆕 Wish 추가 폼 -->
-        <form th:action="@{|/wishes/${product.id}|}" method="post" style="display:inline">
+        <form th:action="@{'/wishes/' + ${product.id}}" method="post" style="display:inline">
           <button type="submit">🤍 찜</button>
         </form>
       </td>
     </tr>
     </tbody>
   </table>
+</div>
+
+<div class="button-group">
+  <a th:href="@{/wishes}" class="button">← 찜 목록으로</a>
 </div>
 
 </body>

--- a/src/test/java/gift/ApprovedProductRepositoryTest.java
+++ b/src/test/java/gift/ApprovedProductRepositoryTest.java
@@ -1,0 +1,38 @@
+package gift;
+
+import gift.entity.ApprovedProduct;
+import gift.repository.ApprovedProductRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+public class ApprovedProductRepositoryTest {
+
+    @Autowired
+    private ApprovedProductRepository approvedProductRepository;
+
+    @Test
+    @DisplayName("existsByName: 저장된 이름에 대해 true 반환")
+    void existsByName_shouldReturnTrue_whenNameExists() {
+        // given
+        ApprovedProduct product = new ApprovedProduct("TestProduct");
+        approvedProductRepository.save(product);
+
+        // when
+        boolean exists = approvedProductRepository.existsByName("TestProduct");
+
+        // then
+        assertThat(exists).isTrue();
+    }
+
+    @Test
+    @DisplayName("existsByName: 저장되지 않은 이름에 대해 false 반환")
+    void existsByName_shouldReturnFalse_whenNameNotExists() {
+        boolean exists = approvedProductRepository.existsByName("NoSuchProduct");
+        assertThat(exists).isFalse();
+    }
+}

--- a/src/test/java/gift/MemberRepositoryTest.java
+++ b/src/test/java/gift/MemberRepositoryTest.java
@@ -1,0 +1,44 @@
+package gift;
+
+import gift.entity.Member;
+import gift.repository.MemberRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+public class MemberRepositoryTest {
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Test
+    @DisplayName("findByEmail & existsByEmail: 저장된 이메일에 대해 조회 및 존재 확인")
+    void findByEmail_and_existsByEmail_shouldWork() {
+        // given
+        Member m = new Member("user@example.com", "secret");
+        memberRepository.save(m);
+
+        // when
+        Optional<Member> found = memberRepository.findByEmail("user@example.com");
+        boolean exists = memberRepository.existsByEmail("user@example.com");
+
+        // then
+        assertThat(found).isPresent();
+        assertThat(found.get().getEmail()).isEqualTo("user@example.com");
+        assertThat(found.get().getIsAdmin()).isFalse();
+        assertThat(exists).isTrue();
+    }
+
+    @Test
+    @DisplayName("findByEmail: 없는 이메일 조회 시 empty 반환")
+    void findByEmail_shouldReturnEmpty_whenNotExists() {
+        Optional<Member> found = memberRepository.findByEmail("noone@example.com");
+        assertThat(found).isEmpty();
+    }
+}

--- a/src/test/java/gift/ProductControllerTest.java
+++ b/src/test/java/gift/ProductControllerTest.java
@@ -497,7 +497,7 @@ public class ProductControllerTest {
 
         var dto = new ProductUpdateRequestDto(
             "다크 초콜릿",
-            -1000,
+            1500,
             ""
         );
 

--- a/src/test/java/gift/ProductRepositoryTest.java
+++ b/src/test/java/gift/ProductRepositoryTest.java
@@ -1,0 +1,53 @@
+package gift;
+
+import gift.entity.Product;
+import gift.repository.ProductRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+public class ProductRepositoryTest {
+
+    @Autowired
+    private ProductRepository productRepository;
+
+    @Test
+    @DisplayName("save & findById: 저장된 상품을 조회할 수 있다")
+    void save_and_findById_shouldWork() {
+        // given
+        Product p = new Product("Chocolate", 1000, "http://example.com/img.png");
+        productRepository.save(p);
+
+        // when
+        Product found = productRepository.findById(p.getId()).orElseThrow();
+
+        // then
+        assertThat(found.getName()).isEqualTo("Chocolate");
+        assertThat(found.getPrice()).isEqualTo(1000);
+        assertThat(found.getImageUrl()).isEqualTo("http://example.com/img.png");
+    }
+
+    @Test
+    @DisplayName("findAll: 저장된 상품 리스트를 모두 반환")
+    void findAll_shouldReturnAllSaved() {
+        productRepository.save(new Product("A", 1, "http://exampleA.com/img.png"));
+        productRepository.save(new Product("B", 2, "http://exampleB.com/img.png"));
+
+        List<Product> all = productRepository.findAll();
+        assertThat(all).hasSize(2)
+                .extracting(Product::getName)
+                .containsExactlyInAnyOrder("A", "B");
+        assertThat(all).hasSize(2)
+                .extracting(Product::getPrice)
+                .containsExactlyInAnyOrder(1, 2);
+        assertThat(all).hasSize(2)
+                .extracting(Product::getImageUrl)
+                .containsExactlyInAnyOrder("http://exampleA.com/img.png", "http://exampleB.com/img.png");
+    }
+}

--- a/src/test/java/gift/WishRepositoryTest.java
+++ b/src/test/java/gift/WishRepositoryTest.java
@@ -1,124 +1,66 @@
 package gift;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
+import gift.entity.Member;
+import gift.entity.Product;
 import gift.entity.WishItem;
+import gift.repository.MemberRepository;
+import gift.repository.ProductRepository;
 import gift.repository.WishRepository;
-import java.util.List;
-import java.util.Objects;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
-import org.springframework.boot.test.autoconfigure.jdbc.JdbcTest;
-import org.springframework.context.annotation.Import;
-import org.springframework.jdbc.core.simple.JdbcClient;
-import org.springframework.jdbc.support.GeneratedKeyHolder;
-import org.springframework.jdbc.support.KeyHolder;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
-@JdbcTest
-@Import(WishRepository.class)
-@AutoConfigureTestDatabase(replace = Replace.NONE)
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
 public class WishRepositoryTest {
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private ProductRepository productRepository;
 
     @Autowired
     private WishRepository wishRepository;
 
-    @Autowired
-    private JdbcClient jdbcClient;
+    @Test
+    @DisplayName("findAllByMemberId: 해당 회원의 찜 목록 조회")
+    void findAllByMemberId_shouldReturnItems_forMember() {
+        // given
+        Member m = memberRepository.save(new Member("u1@example.com", "password"));
+        Product p = productRepository.save(new Product("P1", 1000, "http://example.com/img.png"));
+        WishItem wi = new WishItem(m, p, 3);
+        wishRepository.save(wi);
 
-    Long memberId;
-    Long chocolateId;
-    Long candyId;
+        // when
+        List<WishItem> list = wishRepository.findAllByMemberId(m.getId());
 
-    @BeforeEach
-    void setUp() {
-        KeyHolder memberKeyHolder = new GeneratedKeyHolder();
-        KeyHolder productKeyHolder = new GeneratedKeyHolder();
-
-        jdbcClient.sql("""
-                INSERT INTO members (email, password, is_admin)
-                VALUES (?, ?, ?)
-                """).param(1, "user@example.com")
-            .param(2, "userPassword")
-            .param(false)
-            .update(memberKeyHolder, "id");
-
-        memberId = memberKeyHolder.getKey().longValue();
-
-        jdbcClient.sql("""
-            INSERT INTO products (name, price, image_url)
-            VALUES (?, ?, ?)
-            """).param(1, "초콜릿")
-            .param(2, "1500")
-            .param(3, "https://www.chocolate.png")
-            .update(productKeyHolder, "id");
-
-        chocolateId = productKeyHolder.getKey().longValue();
-
-        jdbcClient.sql("""
-            INSERT INTO products (name, price, image_url)
-            VALUES (?, ?, ?)
-            """).param(1, "사탕")
-            .param(2, "500")
-            .param(3, "https://www.candy.png")
-            .update(productKeyHolder, "id");
-
-        candyId = productKeyHolder.getKey().longValue();
-
-        jdbcClient.sql("""
-            INSERT INTO wish_items (member_id, product_id, quantity)
-            VALUES (?, ?, ?)
-            """).param(1, memberId)
-            .param(2, chocolateId)
-            .param(3, 1)
-            .update();
+        // then
+        assertThat(list).hasSize(1);
+        assertThat(list.getFirst().getProduct().getName()).isEqualTo("P1");
+        assertThat(list.getFirst().getProduct().getPrice()).isEqualTo(10);
+        assertThat(list.getFirst().getProduct().getImageUrl()).isEqualTo("http://example.com/img.png");
+        assertThat(list.getFirst().getQuantity()).isEqualTo(3);
     }
 
     @Test
-    @DisplayName("memberId 로 wishlist 목록 조회")
-    void findAllByMemberId() {
-        List<WishItem> list = wishRepository.findAllByMemberId(memberId);
+    @DisplayName("deleteByMemberIdAndProductId: 해당 항목 삭제 후 영향 개수 반환")
+    void deleteByMemberIdAndProductId_shouldDeleteAndReturnCount() {
+        // given
+        Member m = memberRepository.save(new Member("u2@example.com", "password"));
+        Product p = productRepository.save(new Product("P2", 2000, "http://example.com/img.png"));
+        WishItem wi = new WishItem(m, p, 5);
+        wishRepository.save(wi);
 
-        assertThat(list)
-            .hasSize(1)
-            .first()
-            .satisfies(item -> {
-                assertThat(item.getMemberId()).isEqualTo(memberId);
-                assertThat(item.getProductId()).isEqualTo(chocolateId);
-                assertThat(item.getProductName()).isEqualTo("초콜릿");
-                assertThat(item.getPrice()).isEqualTo(1500);
-                assertThat(item.getImageUrl()).isEqualTo("https://www.chocolate.png");
-                assertThat(item.getQuantity()).isEqualTo(1);
-            });
-    }
+        // when
+        int deleted = wishRepository.deleteByMemberIdAndProductId(m.getId(), p.getId());
 
-    @Test
-    @DisplayName("없는 항목은 INSERT, 있으면 수량 누적 업데이트")
-    void updateOrInsertWishItem() {
-        // 위시 리스트에 없는 새 상품(사탕) 추가 → INSERT
-        wishRepository.updateOrInsertWishItem(memberId, candyId, 2);
-        // 같은 상품(사탕) 다시 추가 → UPDATE (2 → 5)
-        wishRepository.updateOrInsertWishItem(memberId, candyId, 3);
-
-        int qty = wishRepository.findAllByMemberId(memberId)
-            .stream()
-            .filter(wi -> Objects.equals(wi.getProductId(), candyId))
-            .findFirst()
-            .orElseThrow()
-            .getQuantity();
-
-        assertThat(qty).isEqualTo(5);
-    }
-
-    @Test
-    @DisplayName("memberId + productId 로 wishlist 항목 삭제")
-    void deleteWishItem() {
-        int affected = wishRepository.delete(memberId, chocolateId);
-
-        assertThat(affected).isEqualTo(1);          // 삭제된 행 수
-        assertThat(wishRepository.findAllByMemberId(memberId)).isEmpty();
+        // then
+        assertThat(deleted).isEqualTo(1);
+        assertThat(wishRepository.findAllByMemberId(m.getId())).isEmpty();
     }
 }

--- a/src/test/java/gift/WishViewControllerTest.java
+++ b/src/test/java/gift/WishViewControllerTest.java
@@ -1,6 +1,7 @@
 package gift;
 
 import gift.auth.LoginMemberArgumentResolver;
+import gift.dto.api.WishRequestDto;
 import gift.entity.Member;
 import gift.entity.Product;
 import gift.exception.InvalidAuthorizationHeaderException;
@@ -8,6 +9,7 @@ import gift.exception.MissingAuthorizationHeaderException;
 import gift.repository.MemberRepository;
 import gift.repository.ProductRepository;
 import gift.repository.WishRepository;
+import gift.service.WishService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -44,6 +46,9 @@ public class WishViewControllerTest {
 
     @Autowired
     private WishRepository wishRepository;
+
+    @Autowired
+    private WishService wishService;
 
     @MockitoBean
     private LoginMemberArgumentResolver loginMemberArgumentResolver;
@@ -128,7 +133,7 @@ public class WishViewControllerTest {
     void list_withItem_ok() throws Exception {
         Product p = productRepository.save(
             new Product("초콜릿", 1000, "https://image.com/choco.png"));
-        wishRepository.updateOrInsertWishItem(member.getId(), p.getId(), 1);
+        wishService.addWishItemForMember(member, new WishRequestDto(p.getId(), 1));
 
         mockMvc.perform(get("/wishes")
                 .header("Authorization", "Bearer dummy"))
@@ -165,8 +170,8 @@ public class WishViewControllerTest {
         Product p2 = productRepository.save(
             new Product("캔디", 500, "https://image.com/candy.png"));
 
-        wishRepository.updateOrInsertWishItem(member.getId(), p1.getId(), 1);
-        wishRepository.updateOrInsertWishItem(member.getId(), p2.getId(), 2);
+        wishService.addWishItemForMember(member, new WishRequestDto(p1.getId(), 1));
+        wishService.addWishItemForMember(member, new WishRequestDto(p2.getId(), 2));
 
         // when & then
         mockMvc.perform(get("/wishes")
@@ -213,7 +218,7 @@ public class WishViewControllerTest {
     void delete_ok_redirect() throws Exception {
         Product p = productRepository.save(
             new Product("사탕", 500, "https://image.com/candy.png"));
-        wishRepository.updateOrInsertWishItem(member.getId(), p.getId(), 1);
+        wishService.addWishItemForMember(member, new WishRequestDto(p.getId(), 1));
 
         mockMvc.perform(post("/wishes/{productId}/delete", p.getId())
                 .header("Authorization", "Bearer dummy"))


### PR DESCRIPTION
### 📋 구현 내역

DB Migration
- `members`, `products`, `wish_items`, `approved_products` 테이블 DDL 스크립트 수정

Entity 클래스
- `Member`, `Product`, `ApprovedProduct`, `WishItem` 엔티티 정의 및 매핑
- 양방향 연관관계(@OneToMany, @ManyToOne), 제약조건(nullable, unique) 적용

Repository 인터페이스
- `MemberRepository`, `ProductRepository`, `ApprovedProductRepository`, `WishRepository` 생성
- 커스텀 메서드(existsByName, existsByEmail, findByEmail, findAllByMemberId, deleteByMemberIdAndProductId) 선언

설정 변경
- application.yml
    - MySQL/H2(test) 데이터소스 분리
    - spring.jpa.show-sql=true, hibernate.format_sql=true 설정
    - 테스트 프로파일에 ddl-auto: create 적용

Service 레이어 리팩토링
- 기존 JdbcClient* 구현체 → JPA 리포지토리 주입으로 전환

단위 테스트
- @DataJpaTest 기반 Repository 테스트 작성 (엔티티 매핑 및 커스텀 메서드 검증)

코드 정리
- 불필요해진 JdbcClient* 클래스 및 설정 제거