### PR TITLE
Step2 Implementation (경북대 BE 김민우)

### DIFF
--- a/API.md
+++ b/API.md
@@ -76,18 +76,29 @@
     <tr>
       <td>GET</td>
       <td>/api/products</td>
-      <td>전체 상품 조회</td>
+      <td>전체 상품 조회 (페이징)</td>
       <td>(Anyone)</td>
-      <td>없음</td>
-      <td><pre><code>[
-  {
-    "id": "(Long)",
-    "name": "(String)",
-    "price": "(Integer)",
-    "imageUrl": "(String)",
-    "validated": "(Boolean)"
-  }
-]</code></pre></td>
+      <td>Query Parameters:<br>
+      - page: (Integer, optional, default=0)<br>
+      - size: (Integer, optional, default=10)<br>
+      - validated: (Boolean, optional, default=true)</td>
+      <td><pre><code>{
+  "content": [
+    {
+      "id": "(Long)",
+      "name": "(String)",
+      "price": "(Integer)",
+      "imageUrl": "(String)",
+      "validated": "(Boolean)"
+    }
+  ],
+  "number": "(Integer)",
+  "size": "(Integer)",
+  "totalElements": "(Long)",
+  "totalPages": "(Integer)",
+  "first": "(Boolean)",
+  "last": "(Boolean)",
+}</code></pre></td>
     </tr>
     <tr>
       <td>PATCH</td>
@@ -118,19 +129,29 @@
 <tr>
       <td>GET</td>
       <td>/api/wishlist</td>
-      <td>내 위시리스트 조회</td>
+      <td>내 위시리스트 조회 (페이징)</td>
       <td>(Anyone Validated)</td>
-      <td>없음</td>
-      <td><pre><code>[
-  {
-    "id": "(Long)",
-    "productId": "(Long)",
-    "productName": "(String)",
-    "productImageUrl": "(String)",
-    "deleted": "(Boolean)",
-    "addedAt": "(LocalDateTime)"
-  }
-]</code></pre></td>
+      <td>Query Parameters:<br>
+      - page: (Integer, optional, default=0)<br>
+      - size: (Integer, optional, default=10)</td>
+      <td><pre><code>{
+  "content": [
+    {
+      "id": "(Long)",
+      "productId": "(Long)",
+      "productName": "(String)",
+      "productImageUrl": "(String)",
+      "deleted": "(Boolean)",
+      "addedAt": "(LocalDateTime)"
+    }
+  ],
+  "number": "(Integer)",
+  "size": "(Integer)",
+  "totalElements": "(Long)",
+  "totalPages": "(Integer)",
+  "first": "(Boolean)",
+  "last": "(Boolean)",
+}</code></pre></td>
     </tr>
     <tr>
       <td>POST</td>
@@ -162,20 +183,20 @@
 
 ## View 렌더링
 
-| Method | URL                  | 설명           | 권한 (Role)             | Parameters                                    | View                            |
-|--------|----------------------|--------------|-----------------------|-----------------------------------------------|---------------------------------|
-| GET    | /admin/products      | 상품 목록 페이지    | ROLE_MD<br>ROLE_CS    | `validated` (Boolean, optional, default=true) | `admin/product-list`            |
-| GET    | /admin/products/{id} | 상품 상세 페이지    | ROLE_MD<br>ROLE_CS    | 없음                                            | `admin/product-form`            |
-| PUT    | /admin/products/{id} | 상품 수정        | ROLE_MD               | 없음                                            | `redirect:/admin/products/{id}` |
-| PATCH  | /admin/products/{id} | 상품 유효성 상태 변경 | ROLE_MD               | `validated` (Boolean, required)               | `redirect:/admin/products/{id}` |
-| DELETE | /admin/products/{id} | 상품 삭제        | ROLE_MD               | 없음                                            | `redirect:/admin/products`      |
-| GET    | /admin/products/new  | 상품 등록 페이지    | ROLE_MD               | 없음                                            | `admin/product-form`            |
-| POST   | /admin/products      | 상품 등록        | ROLE_MD               | 없음                                            | `redirect:/admin/products/{id}` |
-| GET    | /admin               | 관리자 메인 페이지   | (Anyone)              | 없음                                            | `admin/index`                   |
-| GET    | /admin/login         | 관리자 로그인 페이지  | (Anyone)              | 없음                                            | `admin/login`                   |
-| GET    | /admin/members       | 회원 목록 페이지    | ROLE_ADMIN<br>ROLE_CS | 없음                                            | `admin/member-list`             |
-| GET    | /admin/members/{id}  | 회원 상세 페이지    | ROLE_ADMIN<br>ROLE_CS | 없음                                            | `admin/member-form`             |
-| PATCH  | /admin/members/{id}  | 회원 정보 수정     | ROLE_ADMIN            | 없음                                            | `redirect:/admin/members/{id}`  |
-| DELETE | /admin/members/{id}  | 회원 삭제        | ROLE_ADMIN            | 없음                                            | `redirect:/admin/members`       |
-| GET    | /admin/members/new   | 회원 등록 페이지    | ROLE_ADMIN            | 없음                                            | `admin/member-form`             |
-| POST   | /admin/members       | 회원 등록        | ROLE_ADMIN            | 없음                                            | `redirect:/admin/members/{id}`  |
+| Method | URL                  | 설명           | 권한 (Role)             | Parameters                                                                                                                       | View                            |
+|--------|----------------------|--------------|-----------------------|----------------------------------------------------------------------------------------------------------------------------------|---------------------------------|
+| GET    | /admin/products      | 상품 목록 페이지    | ROLE_MD<br>ROLE_CS    | `validated` (Boolean, optional, default=true)<br>`page` (Integer, optional, default=0)<br>`size` (Integer, optional, default=10) | `admin/product-list`            |
+| GET    | /admin/products/{id} | 상품 상세 페이지    | ROLE_MD<br>ROLE_CS    | 없음                                                                                                                               | `admin/product-form`            |
+| PUT    | /admin/products/{id} | 상품 수정        | ROLE_MD               | 없음                                                                                                                               | `redirect:/admin/products/{id}` |
+| PATCH  | /admin/products/{id} | 상품 유효성 상태 변경 | ROLE_MD               | `validated` (Boolean, required)                                                                                                  | `redirect:/admin/products/{id}` |
+| DELETE | /admin/products/{id} | 상품 삭제        | ROLE_MD               | 없음                                                                                                                               | `redirect:/admin/products`      |
+| GET    | /admin/products/new  | 상품 등록 페이지    | ROLE_MD               | 없음                                                                                                                               | `admin/product-form`            |
+| POST   | /admin/products      | 상품 등록        | ROLE_MD               | 없음                                                                                                                               | `redirect:/admin/products/{id}` |
+| GET    | /admin               | 관리자 메인 페이지   | (Anyone)              | 없음                                                                                                                               | `admin/landing-page`            |
+| GET    | /admin/login         | 관리자 로그인 페이지  | (Anyone)              | 없음                                                                                                                               | `admin/login-form`              |
+| GET    | /admin/members       | 회원 목록 페이지    | ROLE_ADMIN<br>ROLE_CS | `page` (Integer, optional, default=0)<br>`size` (Integer, optional, default=10)                                                  | `admin/member-list`             |
+| GET    | /admin/members/{id}  | 회원 상세 페이지    | ROLE_ADMIN<br>ROLE_CS | 없음                                                                                                                               | `admin/member-form`             |
+| PATCH  | /admin/members/{id}  | 회원 정보 수정     | ROLE_ADMIN            | 없음                                                                                                                               | `redirect:/admin/members/{id}`  |
+| DELETE | /admin/members/{id}  | 회원 삭제        | ROLE_ADMIN            | 없음                                                                                                                               | `redirect:/admin/members`       |
+| GET    | /admin/members/new   | 회원 등록 페이지    | ROLE_ADMIN            | 없음                                                                                                                               | `admin/member-form`             |
+| POST   | /admin/members       | 회원 등록        | ROLE_ADMIN            | 없음                                                                                                                               | `redirect:/admin/members/{id}`  |

--- a/API.md
+++ b/API.md
@@ -98,6 +98,7 @@
   "totalPages": "(Integer)",
   "first": "(Boolean)",
   "last": "(Boolean)",
+  "sort": "(String)"
 }</code></pre></td>
     </tr>
     <tr>
@@ -151,6 +152,7 @@
   "totalPages": "(Integer)",
   "first": "(Boolean)",
   "last": "(Boolean)",
+  "sort": "(String)"
 }</code></pre></td>
     </tr>
     <tr>
@@ -183,20 +185,20 @@
 
 ## View 렌더링
 
-| Method | URL                  | 설명           | 권한 (Role)             | Parameters                                                                                                                       | View                            |
-|--------|----------------------|--------------|-----------------------|----------------------------------------------------------------------------------------------------------------------------------|---------------------------------|
-| GET    | /admin/products      | 상품 목록 페이지    | ROLE_MD<br>ROLE_CS    | `validated` (Boolean, optional, default=true)<br>`page` (Integer, optional, default=0)<br>`size` (Integer, optional, default=10) | `admin/product-list`            |
-| GET    | /admin/products/{id} | 상품 상세 페이지    | ROLE_MD<br>ROLE_CS    | 없음                                                                                                                               | `admin/product-form`            |
-| PUT    | /admin/products/{id} | 상품 수정        | ROLE_MD               | 없음                                                                                                                               | `redirect:/admin/products/{id}` |
-| PATCH  | /admin/products/{id} | 상품 유효성 상태 변경 | ROLE_MD               | `validated` (Boolean, required)                                                                                                  | `redirect:/admin/products/{id}` |
-| DELETE | /admin/products/{id} | 상품 삭제        | ROLE_MD               | 없음                                                                                                                               | `redirect:/admin/products`      |
-| GET    | /admin/products/new  | 상품 등록 페이지    | ROLE_MD               | 없음                                                                                                                               | `admin/product-form`            |
-| POST   | /admin/products      | 상품 등록        | ROLE_MD               | 없음                                                                                                                               | `redirect:/admin/products/{id}` |
-| GET    | /admin               | 관리자 메인 페이지   | (Anyone)              | 없음                                                                                                                               | `admin/landing-page`            |
-| GET    | /admin/login         | 관리자 로그인 페이지  | (Anyone)              | 없음                                                                                                                               | `admin/login-form`              |
-| GET    | /admin/members       | 회원 목록 페이지    | ROLE_ADMIN<br>ROLE_CS | `page` (Integer, optional, default=0)<br>`size` (Integer, optional, default=10)                                                  | `admin/member-list`             |
-| GET    | /admin/members/{id}  | 회원 상세 페이지    | ROLE_ADMIN<br>ROLE_CS | 없음                                                                                                                               | `admin/member-form`             |
-| PATCH  | /admin/members/{id}  | 회원 정보 수정     | ROLE_ADMIN            | 없음                                                                                                                               | `redirect:/admin/members/{id}`  |
-| DELETE | /admin/members/{id}  | 회원 삭제        | ROLE_ADMIN            | 없음                                                                                                                               | `redirect:/admin/members`       |
-| GET    | /admin/members/new   | 회원 등록 페이지    | ROLE_ADMIN            | 없음                                                                                                                               | `admin/member-form`             |
-| POST   | /admin/members       | 회원 등록        | ROLE_ADMIN            | 없음                                                                                                                               | `redirect:/admin/members/{id}`  |
+| Method | URL                  | 설명           | 권한 (Role)             | Parameters                                                                                                                                                    | View                            |
+|--------|----------------------|--------------|-----------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------|
+| GET    | /admin/products      | 상품 목록 페이지    | ROLE_MD<br>ROLE_CS    | `validated` (Boolean, optional, default=true)<br>`page` (Integer, optional, default=0)<br>`size` (Integer, optional, default=10)<br>`sort` (String, optional) | `admin/product-list`            |
+| GET    | /admin/products/{id} | 상품 상세 페이지    | ROLE_MD<br>ROLE_CS    | 없음                                                                                                                                                            | `admin/product-form`            |
+| PUT    | /admin/products/{id} | 상품 수정        | ROLE_MD               | 없음                                                                                                                                                            | `redirect:/admin/products/{id}` |
+| PATCH  | /admin/products/{id} | 상품 유효성 상태 변경 | ROLE_MD               | `validated` (Boolean, required)                                                                                                                               | `redirect:/admin/products/{id}` |
+| DELETE | /admin/products/{id} | 상품 삭제        | ROLE_MD               | 없음                                                                                                                                                            | `redirect:/admin/products`      |
+| GET    | /admin/products/new  | 상품 등록 페이지    | ROLE_MD               | 없음                                                                                                                                                            | `admin/product-form`            |
+| POST   | /admin/products      | 상품 등록        | ROLE_MD               | 없음                                                                                                                                                            | `redirect:/admin/products/{id}` |
+| GET    | /admin               | 관리자 메인 페이지   | (Anyone)              | 없음                                                                                                                                                            | `admin/landing-page`            |
+| GET    | /admin/login         | 관리자 로그인 페이지  | (Anyone)              | 없음                                                                                                                                                            | `admin/login-form`              |
+| GET    | /admin/members       | 회원 목록 페이지    | ROLE_ADMIN<br>ROLE_CS | `page` (Integer, optional, default=0)<br>`size` (Integer, optional, default=10)<br>`sort` (String, optional)                                                  | `admin/member-list`             |
+| GET    | /admin/members/{id}  | 회원 상세 페이지    | ROLE_ADMIN<br>ROLE_CS | 없음                                                                                                                                                            | `admin/member-form`             |
+| PATCH  | /admin/members/{id}  | 회원 정보 수정     | ROLE_ADMIN            | 없음                                                                                                                                                            | `redirect:/admin/members/{id}`  |
+| DELETE | /admin/members/{id}  | 회원 삭제        | ROLE_ADMIN            | 없음                                                                                                                                                            | `redirect:/admin/members`       |
+| GET    | /admin/members/new   | 회원 등록 페이지    | ROLE_ADMIN            | 없음                                                                                                                                                            | `admin/member-form`             |
+| POST   | /admin/members       | 회원 등록        | ROLE_ADMIN            | 없음                                                                                                                                                            | `redirect:/admin/members/{id}`  |

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 ### before step2 implementation
 #### [refactor]
 - Entity 클래스
-  - [ ] 엔티티(`Member`, `Product`, `Wish`)의 id setter 제거
+  - [x] 엔티티(`Member`, `Product`, `Wish`)의 id setter 제거
   - [ ] Member 테이블의 컬럼명 변경
     - `@Id` 어노테이션을 사용하는 `IdentifyNumber(identify_number)` 컬럼의 이름을 `id`로 변경
     - `Role` enum 타입의 `authority` 컬럼의 이름을 `role`로 변경

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 #### [refactor]
 - Entity 클래스
   - [x] 엔티티(`Member`, `Product`, `Wish`)의 id setter 제거
-  - [ ] Member 테이블의 컬럼명 변경
+  - [x] Member 테이블의 컬럼명 변경
     - `@Id` 어노테이션을 사용하는 `IdentifyNumber(identify_number)` 컬럼의 이름을 `id`로 변경
     - `Role` enum 타입의 `authority` 컬럼의 이름을 `role`로 변경
   - [ ] Wish 테이블(기존 WishItem 클래스) 리펙터링
@@ -39,13 +39,17 @@
 - Repository 클래스
   - [ ] ProductRepository 인터페이스 리펙터링
     - `findAllByDeletedIsFalseAndValidated` 메소드의 매개변수명을 `visibility`에서 컬럼명인 `validated`로 변경
-  - [ ] Repository 레이어의 메소드명 변경
+  - [x] Repository 레이어의 삭제 메소드 리펙터링
     - `removeOO` 메소드를 `deleteOO`로 변경
+    - 반환타입을 일괄 void형으로 변경
 - Service 클래스
   - [ ] Service 레이어의 `@Transactional` 어노테이션의 사용위치 변경
     - 기존 클래스 단으로 적용하던 `@Transactional` 어노테이션을 메소드별로 변경
   - [ ] Service 레이어의 `throwNotFoundException` 메소드 삭제
     - MemberService, ProductService 클래스에 해당
+  - [x] Service 레이어의 `deleteOO` 메소드 호출부 변경
+    - hard delete 사용되는 MemberService, WishService 클래스에 해당
+    - `deleteOO` 메소드가 void 타입으로 변경됨에 따라, 해당 메소드 호출부 이전에 `findOO` 메소드로 조회 후, 해당 객체가 존재하는지 여부를 확인하는 로직 추가
   - [ ] MemberService 클래스의 `generateRandomPassword` 메소드 위치 변경
     - 별도 utility 클래스로 분리하여 `PasswordUtils` 클래스에 위치
 #### [fix]

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@
     - `UpdateMemberResponse`로 이름 변경 : Dto의 이름은 Request와 Response로 통일
     - `Optional` 타입의 `temporalPassword` 필드를 `String` 타입으로 변경 : Optional 타입은 필드 / 매개변수 / 컬렉션 원소타입으로 사용하지 않도록 조치
 - Repository 클래스
-  - [ ] ProductRepository 인터페이스 리펙터링
+  - [x] ProductRepository 인터페이스 리펙터링
     - `findAllByDeletedIsFalseAndValidated` 메소드의 매개변수명을 `visibility`에서 컬럼명인 `validated`로 변경
   - [x] Repository 레이어의 삭제 메소드 리펙터링
     - `removeOO` 메소드를 `deleteOO`로 변경

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@
 - [x] Wish 테이블 수정
   - Product와의 연관관계 매핑 변경 : `@OneToOne`에서 `@ManyToOne` 어노테이션으로 변경하여, 여러명(여러 Wish)이 하나의 Product를 참조할 수 있도록 조치
 ### Step2 implementation
-- [ ] 페이징 구현
+- [x] 페이징 구현
   - API, Admin Page(Thymeleaf)에서 페이징 기능 구현
   - Admin Page 페이징 UI 구현 (assisted by AI, implemented by bootstrap)
 ### after step2 implementation

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@
   - Admin Page 페이징 UI 구현 (assisted by AI, implemented by bootstrap)
 ### after step2 implementation
 - [x] Admin Page 전역 UI 개선 (assisted by AI, implemented by bootstrap)
-- [ ] Admin Page 예외페이지 정상작동 구현
+- [x] Admin Page 예외페이지 정상작동 구현
   - Custom Exception 및 Custom Exception Handler 구현
 
 ## TODO

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@
   - API, Admin Page(Thymeleaf)에서 페이징 기능 구현
   - Admin Page 페이징 UI 구현 (assisted by AI, implemented by bootstrap)
 ### after step2 implementation
-- [ ] Admin Page 전역 UI 개선 (assisted by AI, implemented by bootstrap)
+- [x] Admin Page 전역 UI 개선 (assisted by AI, implemented by bootstrap)
 - [ ] Admin Page 예외페이지 정상작동 구현
   - Custom Exception 및 Custom Exception Handler 구현
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
     - 클래스명을 `Wish`로 변경 : 테이블명인 `wish`와 클래스명인 `WishItem`의 불일치 해결 목적
     - 접근제어자 추가 : `default`(미기재)에서 `private`로 변경하여 외부에서 접근 불가하도록 조치
 - Dto 클래스
-  - [ ] `UpdateMemberResult` Dto 리팩터링
+  - [x] `UpdateMemberResult` Dto 리팩터링
     - `UpdateMemberResponse`로 이름 변경 : Dto의 이름은 Request와 Response로 통일
     - `Optional` 타입의 `temporalPassword` 필드를 `String` 타입으로 변경 : Optional 타입은 필드 / 매개변수 / 컬렉션 원소타입으로 사용하지 않도록 조치
 - Repository 클래스

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@
   - [x] MemberService 클래스의 `generateRandomPassword` 메소드 위치 변경
     - 별도 utility 클래스로 분리하여 `PasswordUtils` 클래스에 위치
 #### [fix]
-- [ ] Wish 테이블 수정
+- [x] Wish 테이블 수정
   - Product와의 연관관계 매핑 변경 : `@OneToOne`에서 `@ManyToOne` 어노테이션으로 변경하여, 여러명(여러 Wish)이 하나의 Product를 참조할 수 있도록 조치
 
 ## TODO

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@
   - [x] Service 레이어의 `deleteOO` 메소드 호출부 변경
     - hard delete 사용되는 MemberService, WishService 클래스에 해당
     - `deleteOO` 메소드가 void 타입으로 변경됨에 따라, 해당 메소드 호출부 이전에 `findOO` 메소드로 조회 후, 해당 객체가 존재하는지 여부를 확인하는 로직 추가
-  - [ ] MemberService 클래스의 `generateRandomPassword` 메소드 위치 변경
+  - [x] MemberService 클래스의 `generateRandomPassword` 메소드 위치 변경
     - 별도 utility 클래스로 분리하여 `PasswordUtils` 클래스에 위치
 #### [fix]
 - [ ] Wish 테이블 수정

--- a/README.md
+++ b/README.md
@@ -61,9 +61,14 @@
   - API, Admin Page(Thymeleaf)에서 페이징 기능 구현
   - Admin Page 페이징 UI 구현 (assisted by AI, implemented by bootstrap)
 ### after step2 implementation
+#### [feat]
 - [x] Admin Page 전역 UI 개선 (assisted by AI, implemented by bootstrap)
+#### [fix]
 - [x] Admin Page 예외페이지 정상작동 구현
   - Custom Exception 및 Custom Exception Handler 구현
+#### [refactor]
+- [x] Page 반환방법을 Dto 사용하는 것으로 변경
+  - `Page` 객체를 직접 반환하는 대신, `PageResponse` Dto로 변환하여 반환
 
 ## TODO
 ### Whenever is ready

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
   - [x] Member 테이블의 컬럼명 변경
     - `@Id` 어노테이션을 사용하는 `IdentifyNumber(identify_number)` 컬럼의 이름을 `id`로 변경
     - `Role` enum 타입의 `authority` 컬럼의 이름을 `role`로 변경
-  - [ ] Wish 테이블(기존 WishItem 클래스) 리펙터링
+  - [x] Wish 테이블(기존 WishItem 클래스) 리펙터링
     - 클래스명을 `Wish`로 변경 : 테이블명인 `wish`와 클래스명인 `WishItem`의 불일치 해결 목적
     - 접근제어자 추가 : `default`(미기재)에서 `private`로 변경하여 외부에서 접근 불가하도록 조치
 - Dto 클래스

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@
   - [x] Wish 테이블(기존 WishItem 클래스) 리펙터링
     - 클래스명을 `Wish`로 변경 : 테이블명인 `wish`와 클래스명인 `WishItem`의 불일치 해결 목적
     - 접근제어자 추가 : `default`(미기재)에서 `private`로 변경하여 외부에서 접근 불가하도록 조치
+  - [x] 엔티티의 생성자 정리 (생성자 통폐합 및 불필요 생성자 제거)
 - Dto 클래스
   - [x] `UpdateMemberResult` Dto 리팩터링
     - `UpdateMemberResponse`로 이름 변경 : Dto의 이름은 Request와 Response로 통일

--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@
     - `removeOO` 메소드를 `deleteOO`로 변경
     - 반환타입을 일괄 void형으로 변경
 - Service 클래스
-  - [ ] Service 레이어의 `@Transactional` 어노테이션의 사용위치 변경
+  - [x] Service 레이어의 `@Transactional` 어노테이션의 사용위치 변경
     - 기존 클래스 단으로 적용하던 `@Transactional` 어노테이션을 메소드별로 변경
-  - [ ] Service 레이어의 `throwNotFoundException` 메소드 삭제
+  - [x] Service 레이어의 `throwNotFoundException` 메소드 삭제
     - MemberService, ProductService 클래스에 해당
   - [x] Service 레이어의 `deleteOO` 메소드 호출부 변경
     - hard delete 사용되는 MemberService, WishService 클래스에 해당

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # spring-gift-enhancement
 
 ## Step1 PR
+<details>
+<summary>Click to view details</summary>
+
 ### before step1 implementation
 - Member 관련 UpdateRequest 검증위치 변경 및 CustomValidator 삭제 
   - 현행 `NewMemberRequestValidator` class와 `UpdateMemberRequestValidator` class에서 중복이메일검사 등의 검증작업을 분산 
@@ -15,3 +18,44 @@
   - Repository 레이어의 메소드명 변경에 따른 Service 레이어의 호출부 수정
   - Entity 클래스의 어노테이션 추가 및 update 메소드의 setter로의 변환 (불변객체 미반환화)
   - 테스트코드 작성
+
+</details>
+
+## Step2 PR
+### before step2 implementation
+#### [refactor]
+- Entity 클래스
+  - [ ] 엔티티(`Member`, `Product`, `Wish`)의 id setter 제거
+  - [ ] Member 테이블의 컬럼명 변경
+    - `@Id` 어노테이션을 사용하는 `IdentifyNumber(identify_number)` 컬럼의 이름을 `id`로 변경
+    - `Role` enum 타입의 `authority` 컬럼의 이름을 `role`로 변경
+  - [ ] Wish 테이블(기존 WishItem 클래스) 리펙터링
+    - 클래스명을 `Wish`로 변경 : 테이블명인 `wish`와 클래스명인 `WishItem`의 불일치 해결 목적
+    - 접근제어자 추가 : `default`(미기재)에서 `private`로 변경하여 외부에서 접근 불가하도록 조치
+- Dto 클래스
+  - [ ] `UpdateMemberResult` Dto 리팩터링
+    - `UpdateMemberResponse`로 이름 변경 : Dto의 이름은 Request와 Response로 통일
+    - `Optional` 타입의 `temporalPassword` 필드를 `String` 타입으로 변경 : Optional 타입은 필드 / 매개변수 / 컬렉션 원소타입으로 사용하지 않도록 조치
+- Repository 클래스
+  - [ ] ProductRepository 인터페이스 리펙터링
+    - `findAllByDeletedIsFalseAndValidated` 메소드의 매개변수명을 `visibility`에서 컬럼명인 `validated`로 변경
+  - [ ] Repository 레이어의 메소드명 변경
+    - `removeOO` 메소드를 `deleteOO`로 변경
+- Service 클래스
+  - [ ] Service 레이어의 `@Transactional` 어노테이션의 사용위치 변경
+    - 기존 클래스 단으로 적용하던 `@Transactional` 어노테이션을 메소드별로 변경
+  - [ ] Service 레이어의 `throwNotFoundException` 메소드 삭제
+    - MemberService, ProductService 클래스에 해당
+  - [ ] MemberService 클래스의 `generateRandomPassword` 메소드 위치 변경
+    - 별도 utility 클래스로 분리하여 `PasswordUtils` 클래스에 위치
+#### [fix]
+- [ ] Wish 테이블 수정
+  - Product와의 연관관계 매핑 변경 : `@OneToOne`에서 `@ManyToOne` 어노테이션으로 변경하여, 여러명(여러 Wish)이 하나의 Product를 참조할 수 있도록 조치
+
+## TODO
+### Whenever is ready
+#### [refactor]
+- [ ] application.properties 파일을 .yaml 파일로의 변경 및 리펙터링
+  - `jwt.expire-length` 속성의 단위를 주석으로 명시
+#### [feat]
+- [ ] JPA Auditing 적용

--- a/README.md
+++ b/README.md
@@ -56,6 +56,14 @@
 #### [fix]
 - [x] Wish 테이블 수정
   - Product와의 연관관계 매핑 변경 : `@OneToOne`에서 `@ManyToOne` 어노테이션으로 변경하여, 여러명(여러 Wish)이 하나의 Product를 참조할 수 있도록 조치
+### Step2 implementation
+- [ ] 페이징 구현
+  - API, Admin Page(Thymeleaf)에서 페이징 기능 구현
+  - Admin Page 페이징 UI 구현 (assisted by AI, implemented by bootstrap)
+### after step2 implementation
+- [ ] Admin Page 전역 UI 개선 (assisted by AI, implemented by bootstrap)
+- [ ] Admin Page 예외페이지 정상작동 구현
+  - Custom Exception 및 Custom Exception Handler 구현
 
 ## TODO
 ### Whenever is ready

--- a/src/main/java/gift/controller/MemberAdminPageController.java
+++ b/src/main/java/gift/controller/MemberAdminPageController.java
@@ -3,7 +3,7 @@ package gift.controller;
 import gift.dto.CreateMemberRequest;
 import gift.dto.MemberResponse;
 import gift.dto.UpdateMemberRequest;
-import gift.dto.UpdateMemberResult;
+import gift.dto.UpdateMemberResponse;
 import gift.entity.Member;
 import gift.service.MemberService;
 import jakarta.validation.Valid;
@@ -93,16 +93,17 @@ public class MemberAdminPageController {
             model.addAttribute("message", "Invalid input. Check again.\n" + errorMessages);
             return "admin/member-form";
         }
-        UpdateMemberResult updatedMemberResult = memberService.updateSelectivelyMember(
+        UpdateMemberResponse updatedMemberResult = memberService.updateSelectivelyMember(
                 identifyNumber,
                 request.email(),
                 request.resetPassword(),
                 request.authority()
         );
         model.addAttribute("member", UpdateMemberRequest.from(updatedMemberResult.member()));
-        String temporalPasswordInstruction = updatedMemberResult.temporalPassword()
-                .map(password -> "\nTemporary password: " + password)
-                .orElse("");
+        String temporalPassword = updatedMemberResult.temporalPassword();
+        String temporalPasswordInstruction = temporalPassword != null && !temporalPassword.isEmpty()
+                ? "\nTemporary password: " + temporalPassword
+                : "";
         redirectAttributes.addFlashAttribute("message", "Member updated successfully." + temporalPasswordInstruction);
         return "redirect:/admin/members/" + identifyNumber;
     }

--- a/src/main/java/gift/controller/MemberAdminPageController.java
+++ b/src/main/java/gift/controller/MemberAdminPageController.java
@@ -1,9 +1,6 @@
 package gift.controller;
 
-import gift.dto.CreateMemberRequest;
-import gift.dto.MemberResponse;
-import gift.dto.UpdateMemberRequest;
-import gift.dto.UpdateMemberResponse;
+import gift.dto.*;
 import gift.entity.Member;
 import gift.service.MemberService;
 import jakarta.validation.Valid;
@@ -35,7 +32,7 @@ public class MemberAdminPageController {
     ) {
         Page<Member> memberList = memberService.getMemberList(pageable);
         Page<MemberResponse> response = memberList.map(MemberResponse::from);
-        model.addAttribute("members", response);
+        model.addAttribute("members", PageResponse.from(response));
         return "admin/member-list";
     }
 

--- a/src/main/java/gift/controller/MemberAdminPageController.java
+++ b/src/main/java/gift/controller/MemberAdminPageController.java
@@ -62,7 +62,7 @@ public class MemberAdminPageController {
         Member createdMember = memberService.createMember(request.email(), request.password());
         model.addAttribute("member", UpdateMemberRequest.from(createdMember));
         redirectAttributes.addFlashAttribute("message", "Member created successfully.");
-        return "redirect:/admin/members/" + createdMember.getIdentifyNumber();
+        return "redirect:/admin/members/" + createdMember.getId();
     }
 
     @GetMapping("/{id}")

--- a/src/main/java/gift/controller/MemberAdminPageController.java
+++ b/src/main/java/gift/controller/MemberAdminPageController.java
@@ -7,13 +7,15 @@ import gift.dto.UpdateMemberResponse;
 import gift.entity.Member;
 import gift.service.MemberService;
 import jakarta.validation.Valid;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
-import java.util.List;
 import java.util.stream.Collectors;
 
 @Controller
@@ -27,11 +29,12 @@ public class MemberAdminPageController {
     }
 
     @GetMapping
-    public String getMembers(Model model) {
-        List<Member> memberList = memberService.getMemberList();
-        List<MemberResponse> response = memberList.stream()
-                .map(member -> MemberResponse.from(member))
-                .toList();
+    public String getMembers(
+        Pageable pageable,
+        Model model
+    ) {
+        Page<Member> memberList = memberService.getMemberList(pageable);
+        Page<MemberResponse> response = memberList.map(MemberResponse::from);
         model.addAttribute("members", response);
         return "admin/member-list";
     }
@@ -45,10 +48,10 @@ public class MemberAdminPageController {
 
     @PostMapping
     public String createMember(
-            @Valid @ModelAttribute CreateMemberRequest request,
-            BindingResult bindingResult,
-            Model model,
-            RedirectAttributes redirectAttributes
+        @Valid @ModelAttribute CreateMemberRequest request,
+        BindingResult bindingResult,
+        Model model,
+        RedirectAttributes redirectAttributes
     ) {
         if (bindingResult.hasErrors()) {
             model.addAttribute("memberId", null);
@@ -67,8 +70,8 @@ public class MemberAdminPageController {
 
     @GetMapping("/{id}")
     public String getMember(
-            @PathVariable("id") Long identifyNumber,
-            Model model
+        @PathVariable("id") Long identifyNumber,
+        Model model
     ) {
         Member member = memberService.getMemberById(identifyNumber);
         model.addAttribute("member", UpdateMemberRequest.from(member));
@@ -78,11 +81,11 @@ public class MemberAdminPageController {
 
     @PutMapping("/{id}")
     public String updateMember(
-            @PathVariable("id") Long identifyNumber,
-            @Valid @ModelAttribute UpdateMemberRequest request,
-            BindingResult bindingResult,
-            Model model,
-            RedirectAttributes redirectAttributes
+        @PathVariable("id") Long identifyNumber,
+        @Valid @ModelAttribute UpdateMemberRequest request,
+        BindingResult bindingResult,
+        Model model,
+        RedirectAttributes redirectAttributes
     ) {
         if (bindingResult.hasErrors()) {
             model.addAttribute("memberId", identifyNumber);
@@ -97,7 +100,7 @@ public class MemberAdminPageController {
                 identifyNumber,
                 request.email(),
                 request.resetPassword(),
-                request.authority()
+                request.role()
         );
         model.addAttribute("member", UpdateMemberRequest.from(updatedMemberResult.member()));
         String temporalPassword = updatedMemberResult.temporalPassword();
@@ -110,8 +113,8 @@ public class MemberAdminPageController {
 
     @DeleteMapping("/{id}")
     public String deleteMember(
-            @PathVariable("id") Long identifyNumber,
-            RedirectAttributes redirectAttributes
+        @PathVariable("id") Long identifyNumber,
+        RedirectAttributes redirectAttributes
     ) {
         memberService.deleteMember(identifyNumber);
         redirectAttributes.addFlashAttribute("message", "Member deleted successfully.");

--- a/src/main/java/gift/controller/ProductAdminPageController.java
+++ b/src/main/java/gift/controller/ProductAdminPageController.java
@@ -6,13 +6,14 @@ import gift.dto.UpdateProductRequest;
 import gift.entity.Product;
 import gift.service.ProductService;
 import jakarta.validation.Valid;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
-import java.util.List;
 import java.util.stream.Collectors;
 
 @Controller
@@ -27,13 +28,12 @@ public class ProductAdminPageController {
 
     @GetMapping
     public String getProducts(
-            @RequestParam(defaultValue = "true", required = false) Boolean validated,
-            Model model
+        @RequestParam(defaultValue = "true", required = false) Boolean validated,
+        Pageable pageable,
+        Model model
     ) {
-        List<Product> products = productService.getProductList(validated);
-        List<ProductResponse> response = products.stream()
-                .map(product -> ProductResponse.from(product))
-                .toList();
+        Page<Product> products = productService.getProductList(validated, pageable);
+        Page<ProductResponse> response = products.map(ProductResponse::from);
         model.addAttribute("products", response);
         model.addAttribute("validated", validated);
         return "admin/product-list";
@@ -50,10 +50,10 @@ public class ProductAdminPageController {
     // 신규상품 등록 form 받고, 검증 및 redirection 수행
     @PostMapping
     public String newProduct(
-            @Valid @ModelAttribute CreateProductRequest request,
-            BindingResult bindingResult,
-            Model model,
-            RedirectAttributes redirectAttributes
+        @Valid @ModelAttribute CreateProductRequest request,
+        BindingResult bindingResult,
+        Model model,
+        RedirectAttributes redirectAttributes
     ) {
         if (bindingResult.hasErrors()) {
             model.addAttribute("productId", null);
@@ -65,9 +65,9 @@ public class ProductAdminPageController {
             return "admin/product-form";
         }
         Product created = productService.createProduct(
-                request.name(),
-                request.price(),
-                request.imageUrl()
+            request.name(),
+            request.price(),
+            request.imageUrl()
         );
         redirectAttributes.addFlashAttribute("message", writeMessageWithValidated("Product created", created.isValidated()));
         return "redirect:/admin/products/" + created.getId();
@@ -75,9 +75,9 @@ public class ProductAdminPageController {
 
     @PatchMapping("/{id}")
     public String setProductValidated(
-            @PathVariable Long id,
-            @RequestParam Boolean validated,
-            RedirectAttributes redirectAttributes
+        @PathVariable Long id,
+        @RequestParam Boolean validated,
+        RedirectAttributes redirectAttributes
     ) {
         productService.setProductValidated(id, validated);
         redirectAttributes.addFlashAttribute("message", "Product Validated Status Changed");
@@ -86,8 +86,8 @@ public class ProductAdminPageController {
 
     @GetMapping("/{id}")
     public String getProduct(
-            @PathVariable Long id,
-            Model model
+        @PathVariable Long id,
+        Model model
     ) {
         Product product = productService.getProductWhetherDeletedById(id);
         UpdateProductRequest dto = UpdateProductRequest.from(product);
@@ -102,11 +102,11 @@ public class ProductAdminPageController {
 
     @PutMapping("/{id}")
     public String updateProduct(
-            @PathVariable Long id,
-            @Valid @ModelAttribute UpdateProductRequest request,
-            BindingResult bindingResult,
-            Model model,
-            RedirectAttributes redirectAttributes
+        @PathVariable Long id,
+        @Valid @ModelAttribute UpdateProductRequest request,
+        BindingResult bindingResult,
+        Model model,
+        RedirectAttributes redirectAttributes
     ) {
         if (bindingResult.hasErrors()) {
             Product originalProduct = productService.getProductWhetherDeletedById(id);
@@ -118,8 +118,8 @@ public class ProductAdminPageController {
                 model.addAttribute("deleted", true);
             } else {
                 String errorMessages = bindingResult.getFieldErrors().stream()
-                        .map(error -> "- " + error.getDefaultMessage())
-                        .collect(Collectors.joining("\n"));
+                    .map(error -> "- " + error.getDefaultMessage())
+                    .collect(Collectors.joining("\n"));
                 model.addAttribute("message", "Invalid input. Check again.\n" + errorMessages);
                 model.addAttribute("product", request);
                 model.addAttribute("deleted", false);
@@ -138,8 +138,8 @@ public class ProductAdminPageController {
 
     @DeleteMapping("/{id}")
     public String deleteProduct(
-            @PathVariable Long id,
-            RedirectAttributes redirectAttributes
+        @PathVariable Long id,
+        RedirectAttributes redirectAttributes
     ) {
         productService.softDeleteProductById(id);
         redirectAttributes.addFlashAttribute("message", "Product deleted");

--- a/src/main/java/gift/controller/ProductAdminPageController.java
+++ b/src/main/java/gift/controller/ProductAdminPageController.java
@@ -2,6 +2,7 @@ package gift.controller;
 
 import gift.dto.CreateProductRequest;
 import gift.dto.ProductResponse;
+import gift.dto.PageResponse;
 import gift.dto.UpdateProductRequest;
 import gift.entity.Product;
 import gift.service.ProductService;
@@ -34,7 +35,7 @@ public class ProductAdminPageController {
     ) {
         Page<Product> products = productService.getProductList(validated, pageable);
         Page<ProductResponse> response = products.map(ProductResponse::from);
-        model.addAttribute("products", response);
+        model.addAttribute("products", PageResponse.from(response));
         model.addAttribute("validated", validated);
         return "admin/product-list";
     }

--- a/src/main/java/gift/controller/ProductController.java
+++ b/src/main/java/gift/controller/ProductController.java
@@ -1,6 +1,7 @@
 package gift.controller;
 
 import gift.dto.CreateProductRequest;
+import gift.dto.PageResponse;
 import gift.dto.PatchProductRequest;
 import gift.dto.ProductResponse;
 import gift.entity.Product;
@@ -48,12 +49,12 @@ public class ProductController {
     }
 
     @GetMapping
-    public ResponseEntity<Page<ProductResponse>> getAllProducts(Pageable pageable) {
+    public ResponseEntity<PageResponse<ProductResponse>> getAllProducts(Pageable pageable) {
         Page<Product> products = productService.getProductList(true, pageable);
         Page<ProductResponse> response = products.map(ProductResponse::from);
         return ResponseEntity
             .status(HttpStatus.OK)
-            .body(response);
+            .body(PageResponse.from(response));
     }
 
     @PatchMapping("/{id}")

--- a/src/main/java/gift/controller/ProductController.java
+++ b/src/main/java/gift/controller/ProductController.java
@@ -6,11 +6,11 @@ import gift.dto.ProductResponse;
 import gift.entity.Product;
 import gift.service.ProductService;
 import jakarta.validation.Valid;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 @RestController
 @RequestMapping("/api/products")
@@ -24,60 +24,58 @@ public class ProductController {
 
     @PostMapping
     public ResponseEntity<ProductResponse> createProduct(
-            @Valid @RequestBody CreateProductRequest request
+        @Valid @RequestBody CreateProductRequest request
     ) {
         Product created = productService.createProduct(
-                request.name(),
-                request.price(),
-                request.imageUrl()
+            request.name(),
+            request.price(),
+            request.imageUrl()
         );
         return ResponseEntity
-                .status(HttpStatus.CREATED)
-                .header("Location", "/api/products/" + created.getId())
-                .body(ProductResponse.from(created));
+            .status(HttpStatus.CREATED)
+            .header("Location", "/api/products/" + created.getId())
+            .body(ProductResponse.from(created));
     }
 
     @GetMapping("/{id}")
     public ResponseEntity<ProductResponse> getProductById(
-            @PathVariable Long id
+        @PathVariable Long id
     ) {
         Product product = productService.getProductById(id);
         return ResponseEntity
-                .status(HttpStatus.OK)
-                .body(ProductResponse.from(product));
+            .status(HttpStatus.OK)
+            .body(ProductResponse.from(product));
     }
 
     @GetMapping
-    public ResponseEntity<List<ProductResponse>> getAllProducts() {
-        List<Product> products = productService.getProductList(true);
-        List<ProductResponse> response = products.stream()
-                .map(product -> ProductResponse.from(product))
-                .toList();
+    public ResponseEntity<Page<ProductResponse>> getAllProducts(Pageable pageable) {
+        Page<Product> products = productService.getProductList(true, pageable);
+        Page<ProductResponse> response = products.map(ProductResponse::from);
         return ResponseEntity
-                .status(HttpStatus.OK)
-                .body(response);
+            .status(HttpStatus.OK)
+            .body(response);
     }
 
     @PatchMapping("/{id}")
     public ResponseEntity<ProductResponse> updateProductById(
-            @PathVariable Long id,
-            @Valid @RequestBody PatchProductRequest patch
+        @PathVariable Long id,
+        @Valid @RequestBody PatchProductRequest patch
     ) {
         Product product = productService.updateProductById(
-                id,
-                patch.name(),
-                patch.price(),
-                patch.imageUrl()
+            id,
+            patch.name(),
+            patch.price(),
+            patch.imageUrl()
         );
 
         return ResponseEntity
-                .status(HttpStatus.OK)
-                .body(ProductResponse.from(product));
+            .status(HttpStatus.OK)
+            .body(ProductResponse.from(product));
     }
 
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> deleteProductById(
-            @PathVariable Long id
+        @PathVariable Long id
     ) {
         productService.softDeleteProductById(id);
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();

--- a/src/main/java/gift/controller/WishController.java
+++ b/src/main/java/gift/controller/WishController.java
@@ -7,11 +7,11 @@ import gift.entity.Wish;
 import gift.service.WishService;
 import gift.validator.LoginMember;
 import jakarta.validation.Valid;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 @RestController
 @RequestMapping("/api/wishes")
@@ -24,14 +24,15 @@ public class WishController {
     }
 
     @GetMapping
-    public ResponseEntity<List<WishItemResponse>> getWishList(
-        @LoginMember AuthenticatedMember member
+    public ResponseEntity<Page<WishItemResponse>> getWishList(
+        @LoginMember AuthenticatedMember member,
+        Pageable pageable
     ) {
         return ResponseEntity
             .status(HttpStatus.OK)
             .body(
-                wishService.getWishListByMemberId(member.id())
-                    .stream().map(wishItem -> WishItemResponse.from(wishItem)).toList()
+                wishService.getWishListByMemberId(member.id(), pageable)
+                    .map(WishItemResponse::from)
             );
     }
 

--- a/src/main/java/gift/controller/WishController.java
+++ b/src/main/java/gift/controller/WishController.java
@@ -3,8 +3,7 @@ package gift.controller;
 import gift.dto.AddWishItemRequest;
 import gift.dto.AuthenticatedMember;
 import gift.dto.WishItemResponse;
-import gift.entity.Member;
-import gift.entity.WishItem;
+import gift.entity.Wish;
 import gift.service.WishService;
 import gift.validator.LoginMember;
 import jakarta.validation.Valid;
@@ -41,7 +40,7 @@ public class WishController {
         @LoginMember AuthenticatedMember member,
         @RequestBody @Valid AddWishItemRequest request
     ) {
-        WishItem created = wishService.addWishItem(member.id(), request.productId());
+        Wish created = wishService.addWishItem(member.id(), request.productId());
         return ResponseEntity
             .status(HttpStatus.CREATED)
             .header("Location", "/api/wish/" + created.getId())

--- a/src/main/java/gift/controller/WishController.java
+++ b/src/main/java/gift/controller/WishController.java
@@ -2,6 +2,7 @@ package gift.controller;
 
 import gift.dto.AddWishItemRequest;
 import gift.dto.AuthenticatedMember;
+import gift.dto.PageResponse;
 import gift.dto.WishItemResponse;
 import gift.entity.Wish;
 import gift.service.WishService;
@@ -24,15 +25,17 @@ public class WishController {
     }
 
     @GetMapping
-    public ResponseEntity<Page<WishItemResponse>> getWishList(
+    public ResponseEntity<PageResponse<WishItemResponse>> getWishList(
         @LoginMember AuthenticatedMember member,
         Pageable pageable
     ) {
         return ResponseEntity
             .status(HttpStatus.OK)
             .body(
-                wishService.getWishListByMemberId(member.id(), pageable)
-                    .map(WishItemResponse::from)
+                PageResponse.from(
+                    wishService.getWishListByMemberId(member.id(), pageable)
+                        .map(WishItemResponse::from)
+                )
             );
     }
 

--- a/src/main/java/gift/dto/AuthenticatedMember.java
+++ b/src/main/java/gift/dto/AuthenticatedMember.java
@@ -9,6 +9,6 @@ public record AuthenticatedMember (
         Role authority
 ) {
     public static AuthenticatedMember from(Member member) {
-        return new AuthenticatedMember(member.getIdentifyNumber(), member.getEmail(), member.getAuthority());
+        return new AuthenticatedMember(member.getId(), member.getEmail(), member.getRole());
     }
 }

--- a/src/main/java/gift/dto/CreateMemberRequest.java
+++ b/src/main/java/gift/dto/CreateMemberRequest.java
@@ -16,7 +16,7 @@ public record CreateMemberRequest (
         String password,
 
         @NotNull(message = "권한은 제시되어야합니다.")
-        Role authority
+        Role role
 ) {
     public static CreateMemberRequest empty() {
         return new CreateMemberRequest("", "", Role.ROLE_USER);

--- a/src/main/java/gift/dto/ErrorResponse.java
+++ b/src/main/java/gift/dto/ErrorResponse.java
@@ -1,0 +1,16 @@
+package gift.dto;
+
+import org.springframework.http.HttpStatus;
+
+import java.time.LocalDateTime;
+
+public record ErrorResponse (
+        LocalDateTime timestamp,
+        int status,
+        String error,
+        String message
+) {
+    public ErrorResponse(HttpStatus status, String message) {
+        this(LocalDateTime.now(), status.value(), status.getReasonPhrase(), message);
+    }
+}

--- a/src/main/java/gift/dto/MemberResponse.java
+++ b/src/main/java/gift/dto/MemberResponse.java
@@ -3,9 +3,9 @@ package gift.dto;
 import gift.entity.Member;
 
 public record MemberResponse (
-        Long identifyNumber,
+        Long id,
         String email,
-        String authority
+        String role
 ) {
     public static MemberResponse from(Member member) {
         return new MemberResponse(

--- a/src/main/java/gift/dto/MemberResponse.java
+++ b/src/main/java/gift/dto/MemberResponse.java
@@ -9,9 +9,9 @@ public record MemberResponse (
 ) {
     public static MemberResponse from(Member member) {
         return new MemberResponse(
-                member.getIdentifyNumber(),
+                member.getId(),
                 member.getEmail(),
-                member.getAuthority().name()
+                member.getRole().name()
         );
     }
 }

--- a/src/main/java/gift/dto/PageResponse.java
+++ b/src/main/java/gift/dto/PageResponse.java
@@ -13,7 +13,8 @@ public record PageResponse<T> (
         long totalElements,
         int totalPages,
         boolean first,
-        boolean last
+        boolean last,
+        String sort
 ) {
     public static <T> PageResponse<T> from(Page<T> page) {
         return new PageResponse<>(
@@ -23,7 +24,8 @@ public record PageResponse<T> (
                 page.getTotalElements(),
                 page.getTotalPages(),
                 page.isFirst(),
-                page.isLast()
+                page.isLast(),
+                page.getSort().toString()
         );
     }
 }

--- a/src/main/java/gift/dto/PageResponse.java
+++ b/src/main/java/gift/dto/PageResponse.java
@@ -1,0 +1,29 @@
+package gift.dto;
+
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+public record PageResponse<T> (
+        // 실제 데이터
+        List<T> content,
+        // 페이지 정보 (thymeleaf에서 사용)
+        int number,
+        int size,
+        long totalElements,
+        int totalPages,
+        boolean first,
+        boolean last
+) {
+    public static <T> PageResponse<T> from(Page<T> page) {
+        return new PageResponse<>(
+                page.getContent(),
+                page.getNumber(),
+                page.getSize(),
+                page.getTotalElements(),
+                page.getTotalPages(),
+                page.isFirst(),
+                page.isLast()
+        );
+    }
+}

--- a/src/main/java/gift/dto/UpdateMemberRequest.java
+++ b/src/main/java/gift/dto/UpdateMemberRequest.java
@@ -8,7 +8,7 @@ import jakarta.validation.constraints.NotNull;
 // for Admin Page. Authority is required.
 public record UpdateMemberRequest (
         @NotNull(message = "회원 id는 제시되어야합니다.")
-        Long identifyNumber,
+        Long id,
 
         @NotNull(message = "이메일은 제시되어야합니다.")
         @Email(message = "올바른 이메일 양식이 아닙니다.")
@@ -19,7 +19,7 @@ public record UpdateMemberRequest (
         Boolean resetPassword,
 
         @NotNull(message = "권한은 제시되어야합니다.")
-        Role authority
+        Role role
 ) {
         public static UpdateMemberRequest from(Member member) {
                 return new UpdateMemberRequest(

--- a/src/main/java/gift/dto/UpdateMemberRequest.java
+++ b/src/main/java/gift/dto/UpdateMemberRequest.java
@@ -23,10 +23,10 @@ public record UpdateMemberRequest (
 ) {
         public static UpdateMemberRequest from(Member member) {
                 return new UpdateMemberRequest(
-                        member.getIdentifyNumber(),
+                        member.getId(),
                         member.getEmail(),
                         false,
-                        member.getAuthority()
+                        member.getRole()
                 );
         }
 }

--- a/src/main/java/gift/dto/UpdateMemberResponse.java
+++ b/src/main/java/gift/dto/UpdateMemberResponse.java
@@ -4,8 +4,8 @@ import gift.entity.Member;
 
 import java.util.Optional;
 
-public record UpdateMemberResult (
+public record UpdateMemberResponse(
         Member member,
-        Optional<String> temporalPassword
+        String temporalPassword
 ) {
 }

--- a/src/main/java/gift/dto/WishItemResponse.java
+++ b/src/main/java/gift/dto/WishItemResponse.java
@@ -1,6 +1,6 @@
 package gift.dto;
 
-import gift.entity.WishItem;
+import gift.entity.Wish;
 
 import java.time.LocalDateTime;
 
@@ -12,14 +12,14 @@ public record WishItemResponse(
         Boolean deleted,
         LocalDateTime addedAt
 ) {
-    public static WishItemResponse from(WishItem wishItem) {
+    public static WishItemResponse from(Wish wish) {
         return new WishItemResponse(
-                wishItem.getId(),
-                wishItem.getProduct().getId(),
-                wishItem.getProduct().getName(),
-                wishItem.getProduct().getImageUrl(),
-                wishItem.getProduct().isDeleted(),
-                wishItem.getAddedAt()
+                wish.getId(),
+                wish.getProduct().getId(),
+                wish.getProduct().getName(),
+                wish.getProduct().getImageUrl(),
+                wish.getProduct().isDeleted(),
+                wish.getAddedAt()
         );
     }
 }

--- a/src/main/java/gift/entity/Member.java
+++ b/src/main/java/gift/entity/Member.java
@@ -2,7 +2,6 @@ package gift.entity;
 
 import jakarta.persistence.*;
 
-import java.util.ArrayList;
 import java.util.List;
 
 @Entity
@@ -11,7 +10,7 @@ public class Member {
 
     @Id
     @GeneratedValue(strategy = jakarta.persistence.GenerationType.IDENTITY)
-    private Long identifyNumber;
+    private Long id;
 
     @Column(unique = true, nullable = false)
     private String email;
@@ -20,27 +19,26 @@ public class Member {
     private String password;
 
     @Column(nullable = false)
-    private Role authority;
+    private Role role;
 
     @OneToMany(mappedBy = "member")
-    //@JoinColumn(name = "member_id", nullable = false)
     private List<WishItem> wishlist;
 
     protected Member() {}
 
-    public Member(Long identifyNumber, String email, String password, Role authority) {
-        this.identifyNumber = identifyNumber;
+    public Member(Long id, String email, String password, Role role) {
+        this.id = id;
         this.email = email;
         this.password = password;
-        this.authority = authority;
+        this.role = role;
     }
 
     public Member(String email, String password) {
         this(null, email, password, Role.ROLE_USER);
     }
 
-    public Long getIdentifyNumber() {
-        return identifyNumber;
+    public Long getId() {
+        return id;
     }
 
     public void setEmail(String email) {
@@ -51,8 +49,8 @@ public class Member {
         return email;
     }
 
-    public Role getAuthority() {
-        return authority;
+    public Role getRole() {
+        return role;
     }
 
     public void setPassword(String password) {
@@ -71,7 +69,7 @@ public class Member {
             this.password = password;
         }
         if (authority != null) {
-            this.authority = authority;
+            this.role = authority;
         }
     }
 }

--- a/src/main/java/gift/entity/Member.java
+++ b/src/main/java/gift/entity/Member.java
@@ -26,6 +26,7 @@ public class Member {
 
     protected Member() {}
 
+    // all arguments constructor for test code
     public Member(Long id, String email, String password, Role role) {
         this.id = id;
         this.email = email;
@@ -33,8 +34,16 @@ public class Member {
         this.role = role;
     }
 
+    // constructor for member creation. Use as a factory method
+    public Member(String email, String password, Role role) {
+        this.email = email;
+        this.password = password;
+        this.role = role;
+    }
+
+    // constructor for member creation with default role as ROLE_USER (for api)
     public Member(String email, String password) {
-        this(null, email, password, Role.ROLE_USER);
+        this(email, password, Role.ROLE_USER);
     }
 
     public Long getId() {
@@ -71,5 +80,11 @@ public class Member {
         if (authority != null) {
             this.role = authority;
         }
+    }
+
+    public static Member emptyOfId(Long id) {
+        Member member = new Member();
+        member.id = id;
+        return member;
     }
 }

--- a/src/main/java/gift/entity/Member.java
+++ b/src/main/java/gift/entity/Member.java
@@ -39,10 +39,6 @@ public class Member {
         this(null, email, password, Role.ROLE_USER);
     }
 
-    public void setIdentifyNumber(Long identifyNumber) {
-        this.identifyNumber = identifyNumber;
-    }
-
     public Long getIdentifyNumber() {
         return identifyNumber;
     }

--- a/src/main/java/gift/entity/Member.java
+++ b/src/main/java/gift/entity/Member.java
@@ -22,7 +22,7 @@ public class Member {
     private Role role;
 
     @OneToMany(mappedBy = "member")
-    private List<WishItem> wishlist;
+    private List<Wish> wishList;
 
     protected Member() {}
 

--- a/src/main/java/gift/entity/Member.java
+++ b/src/main/java/gift/entity/Member.java
@@ -58,6 +58,10 @@ public class Member {
         return email;
     }
 
+    public void setRole(Role role) {
+        this.role = role;
+    }
+
     public Role getRole() {
         return role;
     }

--- a/src/main/java/gift/entity/Product.java
+++ b/src/main/java/gift/entity/Product.java
@@ -29,17 +29,10 @@ public class Product {
     @Column(nullable = false)
     private Boolean deleted = false;
 
+    // non-argument constructor for JPA
     protected Product() {}
 
-    public Product(Long id, String name, Integer price, String imageUrl, Boolean validated) {
-        this.id = id;
-        this.name = name;
-        this.price = price;
-        this.imageUrl = imageUrl;
-        this.validated = validated;
-    }
-
-    // this constructor is used only for the repository row mapper
+    // all arguments constructor for test code
     public Product(Long id, String name, Integer price, String imageUrl, Boolean validated, Boolean deleted) {
         this.id = id;
         this.name = name;
@@ -49,6 +42,7 @@ public class Product {
         this.deleted = deleted;
     }
 
+    // constructor for product creation. use as a factory method
     public Product(String name, Integer price, String imageUrl) {
         this.name = name;
         this.price = price;
@@ -60,24 +54,12 @@ public class Product {
         return id;
     }
 
-    public void setName(String name) {
-        this.name = name;
-    }
-
     public String getName() {
         return name;
     }
 
-    public void setPrice(Integer price) {
-        this.price = price;
-    }
-
     public Integer getPrice() {
         return price;
-    }
-
-    public void setImageUrl(String imageUrl) {
-        this.imageUrl = imageUrl;
     }
 
     public String getImageUrl() {

--- a/src/main/java/gift/entity/Product.java
+++ b/src/main/java/gift/entity/Product.java
@@ -56,10 +56,6 @@ public class Product {
         this.validated = checkValidatedByName(name);
     }
 
-    public void setId(Long id) {
-        this.id = id;
-    }
-
     public Long getId() {
         return id;
     }

--- a/src/main/java/gift/entity/Wish.java
+++ b/src/main/java/gift/entity/Wish.java
@@ -5,33 +5,32 @@ import jakarta.persistence.*;
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "wish")
-public class WishItem {
+public class Wish {
     @Id
     @GeneratedValue(strategy = jakarta.persistence.GenerationType.IDENTITY)
-    Long id;
+    private Long id;
 
     @ManyToOne
     @JoinColumn(name = "member_id", nullable = false)
-    Member member;
+    private Member member;
 
     @OneToOne
     @JoinColumn(name = "product_id", nullable = false)
-    Product product;
+    private Product product;
 
     @Column(name = "added_at", nullable = false)
-    LocalDateTime addedAt;
+    private LocalDateTime addedAt;
 
-    protected WishItem() {}
+    protected Wish() {}
 
-    public WishItem(Long id, Member member, Product product, LocalDateTime addedAt) {
+    public Wish(Long id, Member member, Product product, LocalDateTime addedAt) {
         this.id = id;
         this.member = member;
         this.product = product;
         this.addedAt = addedAt;
     }
 
-    public WishItem(Long memberId, Product product) {
+    public Wish(Long memberId, Product product) {
         this.member = new Member(memberId, null, null, null);
         this.product = product;
         this.addedAt = LocalDateTime.now();

--- a/src/main/java/gift/entity/Wish.java
+++ b/src/main/java/gift/entity/Wish.java
@@ -14,7 +14,7 @@ public class Wish {
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 
-    @OneToOne
+    @ManyToOne
     @JoinColumn(name = "product_id", nullable = false)
     private Product product;
 

--- a/src/main/java/gift/entity/Wish.java
+++ b/src/main/java/gift/entity/Wish.java
@@ -23,15 +23,9 @@ public class Wish {
 
     protected Wish() {}
 
-    public Wish(Long id, Member member, Product product, LocalDateTime addedAt) {
-        this.id = id;
+    // Constructor for wish creation (and its test code)
+    public Wish(Member member, Product product) {
         this.member = member;
-        this.product = product;
-        this.addedAt = addedAt;
-    }
-
-    public Wish(Long memberId, Product product) {
-        this.member = new Member(memberId, null, null, null);
         this.product = product;
         this.addedAt = LocalDateTime.now();
     }

--- a/src/main/java/gift/exception/ConflictException.java
+++ b/src/main/java/gift/exception/ConflictException.java
@@ -1,0 +1,11 @@
+package gift.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.CONFLICT)
+public class ConflictException extends RuntimeException {
+    public ConflictException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/gift/exception/NotFoundException.java
+++ b/src/main/java/gift/exception/NotFoundException.java
@@ -1,0 +1,11 @@
+package gift.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.NOT_FOUND)
+public class NotFoundException extends RuntimeException {
+    public NotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/gift/handler/GlobalRestControllerExceptionHandler.java
+++ b/src/main/java/gift/handler/GlobalRestControllerExceptionHandler.java
@@ -1,7 +1,10 @@
 package gift.handler;
 
 import com.sun.jdi.request.DuplicateRequestException;
+import gift.dto.ErrorResponse;
+import gift.exception.ConflictException;
 import gift.exception.InvalidCredentialsException;
+import gift.exception.NotFoundException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -17,28 +20,30 @@ import java.util.stream.Collectors;
 public class GlobalRestControllerExceptionHandler {
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<String> handleValidationException(MethodArgumentNotValidException ex) {
+    public ResponseEntity<ErrorResponse> handleValidationException(MethodArgumentNotValidException ex) {
+        HttpStatus status = HttpStatus.BAD_REQUEST;
         String errorMessages = ex.getBindingResult().getFieldErrors().stream()
-                .map(err -> "- " + err.getField() + ": " + err.getDefaultMessage())
-                .collect(Collectors.joining("\n"));
-
-        return ResponseEntity.badRequest().body("Invalid input. Check again.\n" + errorMessages);
+                .map(err -> err.getField() + ": " + err.getDefaultMessage())
+                .collect(Collectors.joining(" / "));
+        ErrorResponse errorResponse = new ErrorResponse(status, "Invalid input - " + errorMessages);
+        return ResponseEntity.status(status).body(errorResponse);
     }
 
     @ExceptionHandler(InvalidCredentialsException.class)
-    public ResponseEntity<Map<String, String>> handleInvalidCredentials(InvalidCredentialsException ex) {
-        Map<String, String> error = new HashMap<>();
-        error.put("message", ex.getMessage());
-        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(error);
+    public ResponseEntity<ErrorResponse> handleInvalidCredentials(InvalidCredentialsException ex) {
+        HttpStatus status = HttpStatus.FORBIDDEN;
+        return ResponseEntity.status(status).body(new ErrorResponse(status, ex.getMessage()));
     }
 
-    @ExceptionHandler(DuplicateRequestException.class)
-    public ResponseEntity<String> handleDuplicateRequest(DuplicateRequestException ex) {
-        return ResponseEntity.status(HttpStatus.CONFLICT).body("Duplicate request: " + ex.getMessage());
+    @ExceptionHandler(NotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleNotFoundException(NotFoundException ex) {
+        HttpStatus status = HttpStatus.NOT_FOUND;
+        return ResponseEntity.status(status).body(new ErrorResponse(status, ex.getMessage()));
     }
 
-    @ExceptionHandler(ResponseStatusException.class)
-    public ResponseEntity<String> handleApiException(ResponseStatusException ex) {
-        return ResponseEntity.status(ex.getStatusCode()).body(ex.getMessage());
+    @ExceptionHandler(ConflictException.class)
+    public ResponseEntity<ErrorResponse> handleConflictException(ConflictException ex) {
+        HttpStatus status = HttpStatus.CONFLICT;
+        return ResponseEntity.status(status).body(new ErrorResponse(status, ex.getMessage()));
     }
 }

--- a/src/main/java/gift/handler/GlobalRestControllerExceptionHandler.java
+++ b/src/main/java/gift/handler/GlobalRestControllerExceptionHandler.java
@@ -1,22 +1,21 @@
 package gift.handler;
 
-import com.sun.jdi.request.DuplicateRequestException;
 import gift.dto.ErrorResponse;
 import gift.exception.ConflictException;
 import gift.exception.InvalidCredentialsException;
 import gift.exception.NotFoundException;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
-import org.springframework.web.server.ResponseStatusException;
 
-import java.util.HashMap;
-import java.util.Map;
 import java.util.stream.Collectors;
 
 @RestControllerAdvice
+@Order(Ordered.LOWEST_PRECEDENCE)
 public class GlobalRestControllerExceptionHandler {
 
     @ExceptionHandler(MethodArgumentNotValidException.class)

--- a/src/main/java/gift/handler/MemberAdminPageControllerExceptionHandler.java
+++ b/src/main/java/gift/handler/MemberAdminPageControllerExceptionHandler.java
@@ -1,0 +1,31 @@
+package gift.handler;
+
+import gift.controller.MemberAdminPageController;
+import gift.exception.ConflictException;
+import gift.exception.NotFoundException;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@ControllerAdvice(assignableTypes = MemberAdminPageController.class)
+public class MemberAdminPageControllerExceptionHandler {
+
+    @ExceptionHandler(NotFoundException.class)
+    public String handleNotFoundException(NotFoundException ex, Model model, HttpServletRequest request) {
+        String errorMessage = "Member not found : 유효하지 않은 회원ID로 접근하였습니다.\n" + ex.getMessage();
+        model.addAttribute("errorMessage", errorMessage);
+        String referer = request.getHeader("Referer");
+        model.addAttribute("prevPage", referer);
+        return "error/custom-error";
+    }
+
+    @ExceptionHandler(ConflictException.class)
+    public String handleConflictException(ConflictException ex, Model model, HttpServletRequest request) {
+        String errorMessage = "Conflict Error : 이미 존재하는 회원 이메일입니다.\n" + ex.getMessage();
+        model.addAttribute("errorMessage", errorMessage);
+        String referer = request.getHeader("Referer");
+        model.addAttribute("prevPage", referer);
+        return "error/custom-error";
+    }
+}

--- a/src/main/java/gift/handler/MemberAdminPageControllerExceptionHandler.java
+++ b/src/main/java/gift/handler/MemberAdminPageControllerExceptionHandler.java
@@ -4,12 +4,16 @@ import gift.controller.MemberAdminPageController;
 import gift.exception.ConflictException;
 import gift.exception.NotFoundException;
 import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.core.annotation.Order;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 
 @ControllerAdvice(assignableTypes = MemberAdminPageController.class)
+@Order(1)
 public class MemberAdminPageControllerExceptionHandler {
+
+    private final String mainPage = "/admin/members";
 
     @ExceptionHandler(NotFoundException.class)
     public String handleNotFoundException(NotFoundException ex, Model model, HttpServletRequest request) {
@@ -17,6 +21,7 @@ public class MemberAdminPageControllerExceptionHandler {
         model.addAttribute("errorMessage", errorMessage);
         String referer = request.getHeader("Referer");
         model.addAttribute("prevPage", referer);
+        model.addAttribute("mainPage", mainPage);
         return "error/custom-error";
     }
 
@@ -26,6 +31,7 @@ public class MemberAdminPageControllerExceptionHandler {
         model.addAttribute("errorMessage", errorMessage);
         String referer = request.getHeader("Referer");
         model.addAttribute("prevPage", referer);
+        model.addAttribute("mainPage", mainPage);
         return "error/custom-error";
     }
 }

--- a/src/main/java/gift/handler/ProductAdminPageControllerExceptionHandler.java
+++ b/src/main/java/gift/handler/ProductAdminPageControllerExceptionHandler.java
@@ -1,24 +1,26 @@
 package gift.handler;
 
 import gift.controller.ProductAdminPageController;
-import org.springframework.http.HttpStatus;
+import gift.exception.NotFoundException;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.core.annotation.Order;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
-import org.springframework.web.server.ResponseStatusException;
 
 @ControllerAdvice(assignableTypes = ProductAdminPageController.class)
+@Order(1)
 public class ProductAdminPageControllerExceptionHandler {
 
-    @ExceptionHandler(ResponseStatusException.class)
-    public String handleWebException(ResponseStatusException ex, Model model) {
-        String errorMessage;
-        switch (ex.getStatusCode()) {
-            case HttpStatus.NOT_FOUND -> errorMessage = "Product not found : 유효하지 않은 상품ID로 접근하였습니다.\n";
-            case HttpStatus.INTERNAL_SERVER_ERROR -> errorMessage = "Internal Server Error\n";
-            default -> errorMessage = "Error Occurred\n";
-        }
-        model.addAttribute("errorMessage", errorMessage + ex.getMessage());
+    private final String mainPage = "/admin/products";
+
+    @ExceptionHandler(NotFoundException.class)
+    public String handleNotFoundException(NotFoundException ex, Model model, HttpServletRequest request) {
+        String errorMessage = "Product not found : 유효하지 않은 상품ID로 접근하였습니다.\n" + ex.getMessage();
+        model.addAttribute("errorMessage", errorMessage);
+        String referer = request.getHeader("Referer");
+        model.addAttribute("prevPage", referer);
+        model.addAttribute("mainPage", mainPage);
         return "error/custom-error";
     }
 }

--- a/src/main/java/gift/repository/MemberRepository.java
+++ b/src/main/java/gift/repository/MemberRepository.java
@@ -9,7 +9,5 @@ import java.util.Optional;
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
-    Optional<Member> findByIdentifyNumber(Long identifyNumber);
     Optional<Member> findByEmail(String email);
-    Integer deleteByIdentifyNumber(Long identifyNumber);
 }

--- a/src/main/java/gift/repository/ProductRepository.java
+++ b/src/main/java/gift/repository/ProductRepository.java
@@ -1,15 +1,17 @@
 package gift.repository;
 
 import gift.entity.Product;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface ProductRepository extends JpaRepository<Product, Long> {
 
     Optional<Product> findByIdAndDeletedIsFalse(Long id);
-    List<Product> findAllByDeletedIsFalseAndValidated(Boolean validated);
+
+    Page<Product> findAllByDeletedIsFalseAndValidated(Boolean validated, Pageable pageable);
 }

--- a/src/main/java/gift/repository/ProductRepository.java
+++ b/src/main/java/gift/repository/ProductRepository.java
@@ -11,5 +11,5 @@ import java.util.Optional;
 public interface ProductRepository extends JpaRepository<Product, Long> {
 
     Optional<Product> findByIdAndDeletedIsFalse(Long id);
-    List<Product> findAllByDeletedIsFalseAndValidated(Boolean visibility);
+    List<Product> findAllByDeletedIsFalseAndValidated(Boolean validated);
 }

--- a/src/main/java/gift/repository/WishRepository.java
+++ b/src/main/java/gift/repository/WishRepository.java
@@ -1,15 +1,15 @@
 package gift.repository;
 
-import gift.entity.WishItem;
+import gift.entity.Wish;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
 @Repository
-public interface WishRepository extends JpaRepository<WishItem, Long> {
+public interface WishRepository extends JpaRepository<Wish, Long> {
 
-    List<WishItem> findAllByMemberId(Long memberId);
+    List<Wish> findAllByMemberId(Long memberId);
     boolean existsByIdAndMemberId(Long wishId, Long memberId);
     void deleteByIdAndMemberId(Long wishId, Long memberId);
 }

--- a/src/main/java/gift/repository/WishRepository.java
+++ b/src/main/java/gift/repository/WishRepository.java
@@ -1,15 +1,15 @@
 package gift.repository;
 
 import gift.entity.Wish;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
-
-import java.util.List;
 
 @Repository
 public interface WishRepository extends JpaRepository<Wish, Long> {
 
-    List<Wish> findAllByMemberId(Long memberId);
+    Page<Wish> findAllByMemberId(Long memberId, Pageable pageable);
     boolean existsByMemberIdAndProductId(Long memberId, Long productId);
     boolean existsByIdAndMemberId(Long wishId, Long memberId);
     void deleteByIdAndMemberId(Long wishId, Long memberId);

--- a/src/main/java/gift/repository/WishRepository.java
+++ b/src/main/java/gift/repository/WishRepository.java
@@ -10,6 +10,7 @@ import java.util.List;
 public interface WishRepository extends JpaRepository<Wish, Long> {
 
     List<Wish> findAllByMemberId(Long memberId);
+    boolean existsByMemberIdAndProductId(Long memberId, Long productId);
     boolean existsByIdAndMemberId(Long wishId, Long memberId);
     void deleteByIdAndMemberId(Long wishId, Long memberId);
 }

--- a/src/main/java/gift/repository/WishRepository.java
+++ b/src/main/java/gift/repository/WishRepository.java
@@ -9,6 +9,7 @@ import java.util.List;
 @Repository
 public interface WishRepository extends JpaRepository<WishItem, Long> {
 
-    List<WishItem> findAllByMemberIdentifyNumber(Long memberId);
-    Integer removeByMemberIdentifyNumberAndId(Long memberId, Long wishId);
+    List<WishItem> findAllByMemberId(Long memberId);
+    boolean existsByIdAndMemberId(Long wishId, Long memberId);
+    void deleteByIdAndMemberId(Long wishId, Long memberId);
 }

--- a/src/main/java/gift/service/MemberService.java
+++ b/src/main/java/gift/service/MemberService.java
@@ -8,6 +8,7 @@ import gift.exception.InvalidCredentialsException;
 import gift.repository.MemberRepository;
 import gift.token.JwtTokenProvider;
 import gift.util.BCryptEncryptor;
+import gift.util.PasswordUtility;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -64,7 +65,7 @@ public class MemberService {
         String rawPassword = null;
         String encodedPassword = null;
         if (resetPassword) {
-            rawPassword = generateRandomPassword(10);
+            rawPassword = PasswordUtility.generateRandomPassword(15);
             encodedPassword = BCryptEncryptor.encrypt(rawPassword);
         }
         member.applyPatch(email, encodedPassword, authority);
@@ -103,15 +104,5 @@ public class MemberService {
         Optional<Member> optionalMember = memberRepository.findByEmail(email);
         // 해당 이메일을 사용중인 멤버가 없거나, 이를 요청한 회원이 해당 이메일의 소유자일 경우 (즉, 이메일 변경이 아님)
         return optionalMember.isEmpty() || optionalMember.get().getId().equals(memberId);
-    }
-
-    private String generateRandomPassword(int length) {
-        String chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*";
-        StringBuilder sb = new StringBuilder();
-        java.security.SecureRandom random = new java.security.SecureRandom();
-        for (int i = 0; i < length; i++) {
-            sb.append(chars.charAt(random.nextInt(chars.length())));
-        }
-        return sb.toString();
     }
 }

--- a/src/main/java/gift/service/MemberService.java
+++ b/src/main/java/gift/service/MemberService.java
@@ -55,7 +55,7 @@ public class MemberService {
 
     public UpdateMemberResult updateSelectivelyMember(Long id, String email, Boolean resetPassword, Role authority) {
         Member member = getMemberById(id);
-        checkValidMemberUpdate(email, member.getIdentifyNumber());
+        checkValidMemberUpdate(email, member.getId());
         String rawPassword = null;
         String encodedPassword = null;
         if (resetPassword) {
@@ -67,7 +67,10 @@ public class MemberService {
     }
 
     public void deleteMember(Long id) {
-        throwNotFoundIfTrue(memberRepository.deleteByIdentifyNumber(id) != 1);
+        if (!memberRepository.existsById(id)) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Member not found");
+        }
+        memberRepository.deleteById(id);
     }
 
     public AuthenticatedMember getAuthenticationFromToken(String token) {
@@ -91,7 +94,7 @@ public class MemberService {
     private boolean isEmailUsable(String email, Long memberId) {
         Optional<Member> optionalMember = memberRepository.findByEmail(email);
         // 해당 이메일을 사용중인 멤버가 없거나, 이를 요청한 회원이 해당 이메일의 소유자일 경우 (즉, 이메일 변경이 아님)
-        return optionalMember.isEmpty() || optionalMember.get().getIdentifyNumber().equals(memberId);
+        return optionalMember.isEmpty() || optionalMember.get().getId().equals(memberId);
     }
 
     private String generateRandomPassword(int length) {

--- a/src/main/java/gift/service/MemberService.java
+++ b/src/main/java/gift/service/MemberService.java
@@ -1,7 +1,7 @@
 package gift.service;
 
 import gift.dto.AuthenticatedMember;
-import gift.dto.UpdateMemberResult;
+import gift.dto.UpdateMemberResponse;
 import gift.entity.Member;
 import gift.entity.Role;
 import gift.exception.InvalidCredentialsException;
@@ -53,7 +53,7 @@ public class MemberService {
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Member not found"));
     }
 
-    public UpdateMemberResult updateSelectivelyMember(Long id, String email, Boolean resetPassword, Role authority) {
+    public UpdateMemberResponse updateSelectivelyMember(Long id, String email, Boolean resetPassword, Role authority) {
         Member member = getMemberById(id);
         checkValidMemberUpdate(email, member.getId());
         String rawPassword = null;
@@ -63,7 +63,7 @@ public class MemberService {
             encodedPassword = BCryptEncryptor.encrypt(rawPassword);
         }
         member.applyPatch(email, encodedPassword, authority);
-        return new UpdateMemberResult(member, Optional.ofNullable(rawPassword));
+        return new UpdateMemberResponse(member, rawPassword);
     }
 
     public void deleteMember(Long id) {

--- a/src/main/java/gift/service/MemberService.java
+++ b/src/main/java/gift/service/MemberService.java
@@ -4,17 +4,20 @@ import gift.dto.AuthenticatedMember;
 import gift.dto.UpdateMemberResponse;
 import gift.entity.Member;
 import gift.entity.Role;
+import gift.exception.ConflictException;
 import gift.exception.InvalidCredentialsException;
+import gift.exception.NotFoundException;
 import gift.repository.MemberRepository;
 import gift.token.JwtTokenProvider;
 import gift.util.BCryptEncryptor;
 import gift.util.PasswordUtility;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
 
-import java.util.List;
 import java.util.Optional;
 
 @Service
@@ -47,14 +50,14 @@ public class MemberService {
     }
 
     @Transactional(readOnly = true)
-    public List<Member> getMemberList() {
-        return memberRepository.findAll();
+    public Page<Member> getMemberList(Pageable pageable) {
+        return memberRepository.findAll(pageable);
     }
 
     @Transactional(readOnly = true)
     public Member getMemberById(Long id) {
         return memberRepository.findById(id)
-                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Member not found"));
+                .orElseThrow(() -> new NotFoundException("Member not found"));
     }
 
     @Transactional
@@ -75,7 +78,7 @@ public class MemberService {
     @Transactional
     public void deleteMember(Long id) {
         if (!memberRepository.existsById(id)) {
-            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Member not found");
+            throw new NotFoundException("Member not found");
         }
         memberRepository.deleteById(id);
     }
@@ -95,7 +98,7 @@ public class MemberService {
 
     private void checkValidMemberUpdate(String email, Long memberId) {
         if (!isEmailUsable(email, memberId)) {
-            throw new ResponseStatusException(HttpStatus.CONFLICT, "Email already in use");
+            throw new ConflictException("Email already in use");
         }
     }
 

--- a/src/main/java/gift/service/MemberService.java
+++ b/src/main/java/gift/service/MemberService.java
@@ -8,16 +8,15 @@ import gift.exception.InvalidCredentialsException;
 import gift.repository.MemberRepository;
 import gift.token.JwtTokenProvider;
 import gift.util.BCryptEncryptor;
-import jakarta.transaction.Transactional;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
 import java.util.Optional;
 
 @Service
-@Transactional
 public class MemberService {
 
     private final MemberRepository memberRepository;
@@ -28,6 +27,7 @@ public class MemberService {
         this.jwtTokenProvider = jwtTokenProvider;
     }
 
+    @Transactional
     public Member createMember(String email, String rawPassword) {
         checkValidMemberUpdate(email, null);
 
@@ -36,6 +36,7 @@ public class MemberService {
         return memberRepository.save(member);
     }
 
+    @Transactional(readOnly = true)
     public String login(String email, String rawPassword) {
         Optional<Member> optionalMember = memberRepository.findByEmail(email);
         if (optionalMember.isEmpty() || !BCryptEncryptor.matches(rawPassword, optionalMember.get().getPassword())) {
@@ -44,16 +45,20 @@ public class MemberService {
         return jwtTokenProvider.createToken(optionalMember.get());
     }
 
+    @Transactional(readOnly = true)
     public List<Member> getMemberList() {
         return memberRepository.findAll();
     }
 
+    @Transactional(readOnly = true)
     public Member getMemberById(Long id) {
         return memberRepository.findById(id)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Member not found"));
     }
 
+    @Transactional
     public UpdateMemberResponse updateSelectivelyMember(Long id, String email, Boolean resetPassword, Role authority) {
+        // getMemberById는 readOnly=true이나, 이미 활성화된 Transaction(readOnly=false)에 참여하는 형태
         Member member = getMemberById(id);
         checkValidMemberUpdate(email, member.getId());
         String rawPassword = null;
@@ -66,6 +71,7 @@ public class MemberService {
         return new UpdateMemberResponse(member, rawPassword);
     }
 
+    @Transactional
     public void deleteMember(Long id) {
         if (!memberRepository.existsById(id)) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Member not found");
@@ -73,6 +79,7 @@ public class MemberService {
         memberRepository.deleteById(id);
     }
 
+    @Transactional(readOnly = true)
     public AuthenticatedMember getAuthenticationFromToken(String token) {
         if (token == null || !jwtTokenProvider.validateToken(token)) {
             throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Invalid token");
@@ -91,6 +98,7 @@ public class MemberService {
         }
     }
 
+    // 호출 메소드의 Transaction에 참여
     private boolean isEmailUsable(String email, Long memberId) {
         Optional<Member> optionalMember = memberRepository.findByEmail(email);
         // 해당 이메일을 사용중인 멤버가 없거나, 이를 요청한 회원이 해당 이메일의 소유자일 경우 (즉, 이메일 변경이 아님)
@@ -105,11 +113,5 @@ public class MemberService {
             sb.append(chars.charAt(random.nextInt(chars.length())));
         }
         return sb.toString();
-    }
-
-    private void throwNotFoundIfTrue(boolean condition) {
-        if (condition) {
-            throw new ResponseStatusException(HttpStatus.NOT_FOUND);
-        }
     }
 }

--- a/src/main/java/gift/service/ProductService.java
+++ b/src/main/java/gift/service/ProductService.java
@@ -11,7 +11,6 @@ import java.util.List;
 import java.util.Optional;
 
 @Service
-@Transactional
 public class ProductService {
 
     private final ProductRepository productRepository;
@@ -20,49 +19,54 @@ public class ProductService {
         this.productRepository = productRepository;
     }
 
+    @Transactional
     public Product createProduct(String name, Integer price, String imageUrl) {
         Product product = new Product(name, price, imageUrl);
         return productRepository.save(product);
     }
 
     // for normal users
+    @Transactional(readOnly = true)
     public Product getProductById(Long id) {
         Optional<Product> optionalProduct = productRepository.findByIdAndDeletedIsFalse(id);
-        throwNotFoundIfTrue(optionalProduct.isEmpty());
+        if (optionalProduct.isEmpty()) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Product not found");
+        }
         return optionalProduct.get();
     }
 
     // for md users
+    @Transactional(readOnly = true)
     public Product getProductWhetherDeletedById(Long id) {
         Optional<Product> optionalProduct = productRepository.findById(id);
-        throwNotFoundIfTrue(optionalProduct.isEmpty());
+        if (optionalProduct.isEmpty()) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Product not found");
+        }
         return optionalProduct.get();
     }
 
     // TODO : validated T/F로 나누지 말고, 위 처럼 whetherDeleted로 나누는 걸로 변경 (findAll 사용)
+    @Transactional(readOnly = true)
     public List<Product> getProductList(Boolean validated) {
         return productRepository.findAllByDeletedIsFalseAndValidated(validated);
     }
 
+    @Transactional
     public Product updateProductById(Long id, String name, Integer price, String imageUrl) {
         Product product = getProductById(id);
         product.applyPatch(name, price, imageUrl);
         return product;
     }
 
+    @Transactional
     public void setProductValidated(Long id, Boolean validated) {
         Product product = getProductById(id);
         product.setValidated(validated);
     }
 
+    @Transactional
     public void softDeleteProductById(Long id) {
         Product product = getProductById(id);
         product.setDeleted(true);
-    }
-
-    private void throwNotFoundIfTrue(boolean condition) {
-        if (condition) {
-            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Product not found");
-        }
     }
 }

--- a/src/main/java/gift/service/ProductService.java
+++ b/src/main/java/gift/service/ProductService.java
@@ -1,13 +1,15 @@
 package gift.service;
 
 import gift.entity.Product;
+import gift.exception.NotFoundException;
 import gift.repository.ProductRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
 
-import java.util.List;
 import java.util.Optional;
 
 @Service
@@ -30,7 +32,7 @@ public class ProductService {
     public Product getProductById(Long id) {
         Optional<Product> optionalProduct = productRepository.findByIdAndDeletedIsFalse(id);
         if (optionalProduct.isEmpty()) {
-            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Product not found");
+            throw new NotFoundException("Product not found");
         }
         return optionalProduct.get();
     }
@@ -40,15 +42,15 @@ public class ProductService {
     public Product getProductWhetherDeletedById(Long id) {
         Optional<Product> optionalProduct = productRepository.findById(id);
         if (optionalProduct.isEmpty()) {
-            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Product not found");
+            throw new NotFoundException("Product not found");
         }
         return optionalProduct.get();
     }
 
     // TODO : validated T/F로 나누지 말고, 위 처럼 whetherDeleted로 나누는 걸로 변경 (findAll 사용)
     @Transactional(readOnly = true)
-    public List<Product> getProductList(Boolean validated) {
-        return productRepository.findAllByDeletedIsFalseAndValidated(validated);
+    public Page<Product> getProductList(Boolean validated, Pageable pageable) {
+        return productRepository.findAllByDeletedIsFalseAndValidated(validated, pageable);
     }
 
     @Transactional

--- a/src/main/java/gift/service/WishService.java
+++ b/src/main/java/gift/service/WishService.java
@@ -4,12 +4,10 @@ import gift.entity.Product;
 import gift.entity.WishItem;
 import gift.repository.WishRepository;
 import jakarta.transaction.Transactional;
-import org.springframework.dao.DuplicateKeyException;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
 
-import java.sql.SQLIntegrityConstraintViolationException;
 import java.util.List;
 
 @Service
@@ -25,7 +23,7 @@ public class WishService {
     }
 
     public List<WishItem> getWishListByMemberId(Long memberId) {
-        return wishRepository.findAllByMemberIdentifyNumber(memberId);
+        return wishRepository.findAllByMemberId(memberId);
     }
 
     public WishItem addWishItem(Long memberId, Long productId) {
@@ -40,8 +38,10 @@ public class WishService {
     }
 
     public void removeWishItemByWishId(Long memberId, Long wishId) {
-        if (wishRepository.removeByMemberIdentifyNumberAndId(memberId, wishId) != 1) {
+        if (!wishRepository.existsByIdAndMemberId(wishId, memberId)) {
+            // 본인소유가 아닌 wish의 경우는 hiding 처리됨
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, "WishItem not found");
         }
+        wishRepository.deleteByIdAndMemberId(wishId, memberId);
     }
 }

--- a/src/main/java/gift/service/WishService.java
+++ b/src/main/java/gift/service/WishService.java
@@ -30,12 +30,12 @@ public class WishService {
     public Wish addWishItem(Long memberId, Long productId) {
         // 상품이 존재하는지 확인 및 반환
         Product product = productService.getProductById(productId);
-        try {
-            Wish wish = new Wish(memberId, product);
-            return wishRepository.save(wish);
-        } catch (Exception e) {
+
+        if (wishRepository.existsByMemberIdAndProductId(memberId, productId)) {
             throw new ResponseStatusException(HttpStatus.CONFLICT, "Wish already exists for this product");
         }
+        Wish wish = new Wish(memberId, product);
+        return wishRepository.save(wish);
     }
 
     @Transactional

--- a/src/main/java/gift/service/WishService.java
+++ b/src/main/java/gift/service/WishService.java
@@ -1,7 +1,7 @@
 package gift.service;
 
 import gift.entity.Product;
-import gift.entity.WishItem;
+import gift.entity.Wish;
 import gift.repository.WishRepository;
 import jakarta.transaction.Transactional;
 import org.springframework.http.HttpStatus;
@@ -22,25 +22,25 @@ public class WishService {
         this.productService = productService;
     }
 
-    public List<WishItem> getWishListByMemberId(Long memberId) {
+    public List<Wish> getWishListByMemberId(Long memberId) {
         return wishRepository.findAllByMemberId(memberId);
     }
 
-    public WishItem addWishItem(Long memberId, Long productId) {
+    public Wish addWishItem(Long memberId, Long productId) {
         // 상품이 존재하는지 확인 및 반환
         Product product = productService.getProductById(productId);
         try {
-            WishItem wishItem = new WishItem(memberId, product);
-            return wishRepository.save(wishItem);
+            Wish wish = new Wish(memberId, product);
+            return wishRepository.save(wish);
         } catch (Exception e) {
-            throw new ResponseStatusException(HttpStatus.CONFLICT, "WishItem already exists for this product");
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "Wish already exists for this product");
         }
     }
 
     public void removeWishItemByWishId(Long memberId, Long wishId) {
         if (!wishRepository.existsByIdAndMemberId(wishId, memberId)) {
             // 본인소유가 아닌 wish의 경우는 hiding 처리됨
-            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "WishItem not found");
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Wish not found");
         }
         wishRepository.deleteByIdAndMemberId(wishId, memberId);
     }

--- a/src/main/java/gift/service/WishService.java
+++ b/src/main/java/gift/service/WishService.java
@@ -3,13 +3,14 @@ package gift.service;
 import gift.entity.Member;
 import gift.entity.Product;
 import gift.entity.Wish;
+import gift.exception.ConflictException;
 import gift.repository.WishRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
-
-import java.util.List;
 
 @Service
 public class WishService {
@@ -23,8 +24,8 @@ public class WishService {
     }
 
     @Transactional(readOnly = true)
-    public List<Wish> getWishListByMemberId(Long memberId) {
-        return wishRepository.findAllByMemberId(memberId);
+    public Page<Wish> getWishListByMemberId(Long memberId, Pageable pageable) {
+        return wishRepository.findAllByMemberId(memberId, pageable);
     }
 
     @Transactional
@@ -33,7 +34,7 @@ public class WishService {
         Product product = productService.getProductById(productId);
 
         if (wishRepository.existsByMemberIdAndProductId(memberId, productId)) {
-            throw new ResponseStatusException(HttpStatus.CONFLICT, "Wish already exists for this product");
+            throw new ConflictException("Wish already exists for this product");
         }
         Wish wish = new Wish(Member.emptyOfId(memberId), product);
         return wishRepository.save(wish);

--- a/src/main/java/gift/service/WishService.java
+++ b/src/main/java/gift/service/WishService.java
@@ -1,5 +1,6 @@
 package gift.service;
 
+import gift.entity.Member;
 import gift.entity.Product;
 import gift.entity.Wish;
 import gift.repository.WishRepository;
@@ -34,7 +35,7 @@ public class WishService {
         if (wishRepository.existsByMemberIdAndProductId(memberId, productId)) {
             throw new ResponseStatusException(HttpStatus.CONFLICT, "Wish already exists for this product");
         }
-        Wish wish = new Wish(memberId, product);
+        Wish wish = new Wish(Member.emptyOfId(memberId), product);
         return wishRepository.save(wish);
     }
 

--- a/src/main/java/gift/service/WishService.java
+++ b/src/main/java/gift/service/WishService.java
@@ -3,15 +3,14 @@ package gift.service;
 import gift.entity.Product;
 import gift.entity.Wish;
 import gift.repository.WishRepository;
-import jakarta.transaction.Transactional;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
 
 @Service
-@Transactional
 public class WishService {
 
     private final WishRepository wishRepository;
@@ -22,10 +21,12 @@ public class WishService {
         this.productService = productService;
     }
 
+    @Transactional(readOnly = true)
     public List<Wish> getWishListByMemberId(Long memberId) {
         return wishRepository.findAllByMemberId(memberId);
     }
 
+    @Transactional
     public Wish addWishItem(Long memberId, Long productId) {
         // 상품이 존재하는지 확인 및 반환
         Product product = productService.getProductById(productId);
@@ -37,6 +38,7 @@ public class WishService {
         }
     }
 
+    @Transactional
     public void removeWishItemByWishId(Long memberId, Long wishId) {
         if (!wishRepository.existsByIdAndMemberId(wishId, memberId)) {
             // 본인소유가 아닌 wish의 경우는 hiding 처리됨

--- a/src/main/java/gift/token/JwtTokenProvider.java
+++ b/src/main/java/gift/token/JwtTokenProvider.java
@@ -33,7 +33,7 @@ public class JwtTokenProvider {
 
         return Jwts.builder()
                 .subject(member.getEmail())
-                .claim("role", member.getAuthority().name())
+                .claim("role", member.getRole().name())
                 .issuedAt(now)
                 .expiration(expiry)
                 .signWith(secretKey)

--- a/src/main/java/gift/util/PasswordUtility.java
+++ b/src/main/java/gift/util/PasswordUtility.java
@@ -1,0 +1,14 @@
+package gift.util;
+
+public class PasswordUtility {
+
+    public static String generateRandomPassword(int length) {
+        String chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*";
+        StringBuilder sb = new StringBuilder();
+        java.security.SecureRandom random = new java.security.SecureRandom();
+        for (int i = 0; i < length; i++) {
+            sb.append(chars.charAt(random.nextInt(chars.length())));
+        }
+        return sb.toString();
+    }
+}

--- a/src/main/resources/import.sql
+++ b/src/main/resources/import.sql
@@ -1,3 +1,3 @@
 insert into product(name, price, image_url, validated, deleted) values ('아이스 카페 아메리카노 T', 4700, 'https://st.kakaocdn.net/product/gift/product/20231010111814_9a667f9eccc943648797925498bdd8a3.jpg', true, false);
 
-insert into member(email, password, authority) values ('admin@kakao.com', '$2a$10$KvNzwiNd2I9MAYC/ix4A.et4UjQ/nOff7Y6jl9l6UVie5Gk7UyKfO', 2), ('md@kakao.com', '$2a$10$KvNzwiNd2I9MAYC/ix4A.et4UjQ/nOff7Y6jl9l6UVie5Gk7UyKfO', 3), ('seller@kakao.com', '$2a$10$KvNzwiNd2I9MAYC/ix4A.et4UjQ/nOff7Y6jl9l6UVie5Gk7UyKfO', 1);
+insert into member(email, password, role) values ('admin@kakao.com', '$2a$10$KvNzwiNd2I9MAYC/ix4A.et4UjQ/nOff7Y6jl9l6UVie5Gk7UyKfO', 2), ('md@kakao.com', '$2a$10$KvNzwiNd2I9MAYC/ix4A.et4UjQ/nOff7Y6jl9l6UVie5Gk7UyKfO', 3), ('seller@kakao.com', '$2a$10$KvNzwiNd2I9MAYC/ix4A.et4UjQ/nOff7Y6jl9l6UVie5Gk7UyKfO', 1);

--- a/src/main/resources/templates/admin/landing-page.html
+++ b/src/main/resources/templates/admin/landing-page.html
@@ -3,38 +3,31 @@
 <head>
     <meta charset="UTF-8">
     <title>Landing Page</title>
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
     <style>
         body {
-            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            padding: 20px;
         }
-        a, button {
-            padding: 3px 6px;
-            border-radius: 4px;
-            text-decoration: none;
-            margin-right: 5px;
-            font-size: 14px;
-        }
-        button {
-            cursor: pointer;
-        }
-        a {
-            display: inline-block;
+        .container {
+            margin-top: 20px;
         }
     </style>
 </head>
 <body>
-    <h1>Welcome to the Admin Panel</h1>
-    <h2 th:if="${username != null}" th:text="'Current User: ' + ${username}">Current User</h2>
-    <h2 th:if="${role != null}" th:text="'Current Role: ' + ${role}">Current Role</h2>
+<div class="container">
+    <h1 class="mb-3">Welcome to the Admin Panel</h1>
+    <h2 th:if="${username != null}" th:text="'Current User: ' + ${username}" class="h4">Current User</h2>
+    <h2 th:if="${role != null}" th:text="'Current Role: ' + ${role}" class="h4">Current Role</h2>
     <br>
     <form th:if="${role == null}" th:action="@{/admin/login}" method="get" style="display:inline-block">
-        <button type="submit" style="background-color:black; color:white; border:1px solid black;">Login as Admin</button>
+        <button type="submit" class="btn btn-dark">Login as Admin</button>
     </form>
     <form th:if="${role != null}" th:action="@{/admin/logout}" method="post" style="display:inline-block;">
-        <button type="submit" style="background-color:black; color:white; border:1px solid black; ">Logout</button>
+        <button type="submit" class="btn btn-dark">Logout</button>
     </form>
     <br>
-    <a th:if="${role == 'ROLE_MD'}" href="/admin/products" style="background-color:green; color:white; border:1px solid green;">Go to Product Management</a>
-    <a th:if="${role == 'ROLE_ADMIN'}" href="/admin/members" style="background-color:blue; color:white; border:1px solid blue;">Go to Member Management</a>
+    <a th:if="${role == 'ROLE_MD'}" href="/admin/products" class="btn btn-success mt-2">Go to Product Management</a>
+    <a th:if="${role == 'ROLE_ADMIN'}" href="/admin/members" class="btn btn-primary mt-2">Go to Member Management</a>
+</div>
 </body>
 </html>

--- a/src/main/resources/templates/admin/login-form.html
+++ b/src/main/resources/templates/admin/login-form.html
@@ -3,44 +3,36 @@
 <head>
     <meta charset="UTF-8">
     <title>관리자 로그인</title>
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
     <style>
         body {
-            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            padding: 20px;
         }
-        a, button {
-             padding: 3px 6px;
-             border-radius: 4px;
-             text-decoration: none;
-             margin-right: 5px;
-             font-size: 14px;
-         }
-        button {
-            cursor: pointer;
-        }
-        a {
-            display: inline-block;
+        .container {
+            margin-top: 20px;
+            max-width: 500px;
         }
     </style>
 </head>
 <body>
-    <h1>관리자 로그인</h1>
-    <form th:action="@{/admin/login}"
-          method="post"
-          th:object="${member}">
-        <p>
-            <label>email:</label>
-            <input type="text" th:field="*{email}" />
-        </p>
-        <p>
-            <label>password:</label>
-            <input type="password" th:field="*{password}" />
-        </p>
-        <button type="submit">Login</button>
+<div class="container">
+    <h1 class="mb-3">관리자 로그인</h1>
+    <form th:action="@{/admin/login}" method="post" th:object="${member}">
+        <div class="form-group">
+            <label for="email">Email:</label>
+            <input type="text" id="email" th:field="*{email}" class="form-control" />
+        </div>
+        <div class="form-group">
+            <label for="password">Password:</label>
+            <input type="password" id="password" th:field="*{password}" class="form-control" />
+        </div>
+        <button type="submit" class="btn btn-primary">Login</button>
     </form>
-    <script th:if="${message}" th:inline="javascript">
-        /*<![CDATA[*/
-        alert([[${message}]]);
-        /*]]>*/
-    </script>
+</div>
+<script th:if="${message}" th:inline="javascript">
+    /*<![CDATA[*/
+    alert([[${message}]]);
+    /*]]>*/
+</script>
 </body>
 </html>

--- a/src/main/resources/templates/admin/member-form.html
+++ b/src/main/resources/templates/admin/member-form.html
@@ -31,7 +31,7 @@
         <input type="hidden" name="_method" value="put" th:if="${memberId != null}" />
         <p th:if="${memberId != null}">
             <label>id:</label>
-            <input type="text" th:field="*{identifyNumber}" readonly="readonly" />
+            <input type="text" th:field="*{id}" readonly="readonly" />
         </p>
         <p>
             <label>email:</label>
@@ -45,7 +45,7 @@
         </p>
         <p>
             <label>role:</label>
-            <select th:field="*{authority}">
+            <select th:field="*{role}">
                 <option th:each="role : ${T(gift.entity.Role).values()}"
                         th:value="${role}"
                         th:text="${role}">

--- a/src/main/resources/templates/admin/member-form.html
+++ b/src/main/resources/templates/admin/member-form.html
@@ -3,73 +3,60 @@
 <head>
     <meta charset="UTF-8">
     <title>회원정보 작성</title>
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
     <style>
         body {
-            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            padding: 20px;
         }
-        a, button {
-             padding: 3px 6px;
-             border-radius: 4px;
-             text-decoration: none;
-             margin-right: 5px;
-             font-size: 14px;
-         }
-        button {
-            cursor: pointer;
-        }
-        a {
-            display: inline-block;
+        .container {
+            margin-top: 20px;
+            max-width: 600px;
         }
     </style>
 </head>
 <body>
-    <h1>회원정보 작성</h1>
-    <h2 th:if="${memberId == null}">- 신규 회원</h2>
-    <form th:action="${memberId == null} ? @{/admin/members} : @{/admin/members/{id}(id=${memberId})}"
-          method="post"
-          th:object="${member}">
+<div class="container">
+    <h1 class="mb-3">회원정보 작성</h1>
+    <h2 th:if="${memberId == null}" class="h4">- 신규 회원</h2>
+    <form th:action="${memberId == null} ? @{/admin/members} : @{/admin/members/{id}(id=${memberId})}" method="post" th:object="${member}">
         <input type="hidden" name="_method" value="put" th:if="${memberId != null}" />
-        <p th:if="${memberId != null}">
-            <label>id:</label>
-            <input type="text" th:field="*{id}" readonly="readonly" />
-        </p>
-        <p>
-            <label>email:</label>
-            <input type="text" th:field="*{email}" />
-        </p>
-        <p>
-            <label>password:</label>
-            <input type="password" th:field="*{password}" th:if="${memberId == null}" placeholder="비밀번호는 15자 이상 64자 이내로 작성하십시오" />
-            <input type="checkbox" th:field="*{resetPassword}" th:if="${memberId != null}" />
-            <span th:if="${memberId != null}">비밀번호 초기화 요청 (초기화된 비밀번호는 팝업으로 제공됩니다)</span>
-        </p>
-        <p>
-            <label>role:</label>
-            <select th:field="*{role}">
-                <option th:each="role : ${T(gift.entity.Role).values()}"
-                        th:value="${role}"
-                        th:text="${role}">
-                </option>
+        <div class="form-group" th:if="${memberId != null}">
+            <label for="id">ID:</label>
+            <input type="text" id="id" th:field="*{id}" class="form-control" readonly="readonly" />
+        </div>
+        <div class="form-group">
+            <label for="email">Email:</label>
+            <input type="text" id="email" th:field="*{email}" class="form-control" />
+        </div>
+        <div class="form-group">
+            <label for="password">Password:</label>
+            <input type="password" id="password" th:field="*{password}" class="form-control" th:if="${memberId == null}" placeholder="비밀번호는 15자 이상 64자 이내로 작성하십시오" />
+            <div class="form-check" th:if="${memberId != null}">
+                <input type="checkbox" id="resetPassword" th:field="*{resetPassword}" class="form-check-input" />
+                <label for="resetPassword" class="form-check-label">비밀번호 초기화 요청 (초기화된 비밀번호는 팝업으로 제공됩니다)</label>
+            </div>
+        </div>
+        <div class="form-group">
+            <label for="role">Role:</label>
+            <select id="role" th:field="*{role}" class="form-control">
+                <option th:each="roleValue : ${T(gift.entity.Role).values()}" th:value="${roleValue}" th:text="${roleValue}"></option>
             </select>
-        </p>
-        <button type="submit" th:if="${memberId == null}" >Create</button>
-        <button type="submit" th:if="${memberId != null}" >Apply Changes</button>
+        </div>
+        <button type="submit" class="btn btn-primary" th:if="${memberId == null}">Create</button>
+        <button type="submit" class="btn btn-primary" th:if="${memberId != null}">Apply Changes</button>
     </form>
-    <form th:if="${memberId != null}"
-          th:action="@{/admin/members/{id}(id=${memberId})}"
-          method="post" style="display:inline"
-          onsubmit="return confirm('Are you sure to delete?');">
-        <input type="hidden" name="_method" value="delete" />
-        <button type="submit">Delete</button>
-    </form>
-    <form action="/admin/members"
-          method="get" style="display:inline">
-        <button type="submit">Go to Member List</button>
-    </form>
-    <script th:if="${message}" th:inline="javascript">
-        /*<![CDATA[*/
-        alert([[${message}]]);
-        /*]]>*/
-    </script>
+    <div class="mt-3">
+        <form th:if="${memberId != null}" th:action="@{/admin/members/{id}(id=${memberId})}" method="post" style="display:inline" onsubmit="return confirm('Are you sure to delete?');">
+            <input type="hidden" name="_method" value="delete" />
+            <button type="submit" class="btn btn-danger">Delete</button>
+        </form>
+        <a href="/admin/members" class="btn btn-secondary">Go to Member List</a>
+    </div>
+</div>
+<script th:if="${message}" th:inline="javascript">
+    /*<![CDATA[*/
+    alert([[${message}]]);
+    /*]]>*/
+</script>
 </body>
 </html>

--- a/src/main/resources/templates/admin/member-list.html
+++ b/src/main/resources/templates/admin/member-list.html
@@ -3,67 +3,82 @@
 <head>
     <meta charset="UTF-8">
     <title>회원목록</title>
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
     <style>
         body {
-            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            padding: 20px;
         }
-        a, button {
-            padding: 3px 6px;
-            border-radius: 4px;
-            text-decoration: none;
-            margin-right: 5px;
-            font-size: 14px;
-        }
-        button {
-            cursor: pointer;
-        }
-        a {
-            display: inline-block;
+        .container {
+            margin-top: 20px;
         }
     </style>
 </head>
 <body>
+<div class="container">
     <h2>회원목록</h2>
-    <a href="/admin/members/new"
-       style="background-color:green; color:white; border:1px solid green;">
-        Register New Member
-    </a>
-    <table>
-        <thead>
-            <tr>
-                <th>id</th>
-                <th>email</th>
-                <th>role</th>
-                <th>View/Edit</th>
-                <th>Delete</th>
-            </tr>
+    <div class="mb-3 d-flex justify-content-between align-items-center">
+        <a href="/admin/members/new" class="btn btn-success">Register New Member</a>
+        <form th:action="@{/admin/members}" method="get" class="form-inline">
+            <label for="pageSize" class="mr-2">Items per page:</label>
+            <select id="pageSize" name="size" class="form-control form-control-sm mr-2">
+                <option value="10" th:selected="${members.size == 10}">10</option>
+                <option value="20" th:selected="${members.size == 20}">20</option>
+                <option value="30" th:selected="${members.size == 30}">30</option>
+                <option value="40" th:selected="${members.size == 40}">40</option>
+                <option value="50" th:selected="${members.size == 50}">50</option>
+            </select>
+            <input type="hidden" name="page" th:value="${members.number}">
+            <button type="submit" class="btn btn-info btn-sm">View</button>
+        </form>
+    </div>
+    <table class="table table-bordered table-hover">
+        <thead class="thead-light">
+        <tr>
+            <th>id</th>
+            <th>email</th>
+            <th>role</th>
+            <th>View/Edit</th>
+            <th>Delete</th>
+        </tr>
         </thead>
         <tbody>
-            <tr th:each="member: ${members}">
-                <td th:text="${member.id}" />
-                <td th:text="${member.email}" />
-                <td th:text="${member.role}" />
-                <td>
-                    <form th:action="@{/admin/members/{id}(id=${member.id})}"
-                          method="get" style="display:inline">
-                        <button type="submit">View/Edit</button>
-                    </form>
-                </td>
-                <td>
-                    <form th:action="@{/admin/members/{id}(id=${member.id})}"
-                          method="post" style="display:inline"
-                          onsubmit="return confirm('Are you sure to delete?');">
-                        <input type="hidden" name="_method" value="delete" />
-                        <button type="submit">Delete</button>
-                    </form>
-                </td>
-            </tr>
+        <tr th:each="member: ${members.content}">
+            <td th:text="${member.id}" />
+            <td th:text="${member.email}" />
+            <td th:text="${member.role}" />
+            <td>
+                <a th:href="@{/admin/members/{id}(id=${member.id})}" class="btn btn-primary btn-sm">View/Edit</a>
+            </td>
+            <td>
+                <form th:action="@{/admin/members/{id}(id=${member.id})}"
+                      method="post" style="display:inline"
+                      onsubmit="return confirm('Are you sure to delete?');">
+                    <input type="hidden" name="_method" value="delete" />
+                    <button type="submit" class="btn btn-danger btn-sm">Delete</button>
+                </form>
+            </td>
+        </tr>
         </tbody>
     </table>
-    <script th:if="${message}" th:inline="javascript">
-        /*<![CDATA[*/
-        alert([[${message}]]);
-        /*]]>*/
-    </script>
+
+    <nav aria-label="Page navigation">
+        <ul class="pagination justify-content-center">
+            <li class="page-item" th:classappend="${members.first} ? 'disabled'">
+                <a class="page-link" th:href="@{/admin/members(page=${members.number - 1}, size=${members.size})}">Previous</a>
+            </li>
+            <li class="page-item" th:each="i : ${#numbers.sequence(0, members.totalPages - 1)}" th:classappend="${i == members.number} ? 'active'">
+                <a class="page-link" th:href="@{/admin/members(page=${i}, size=${members.size})}" th:text="${i + 1}"></a>
+            </li>
+            <li class="page-item" th:classappend="${members.last} ? 'disabled'">
+                <a class="page-link" th:href="@{/admin/members(page=${members.number + 1}, size=${members.size})}">Next</a>
+            </li>
+        </ul>
+    </nav>
+</div>
+<script th:if="${message}" th:inline="javascript">
+    /*<![CDATA[*/
+    alert([[${message}]]);
+    /*]]>*/
+</script>
 </body>
 </html>

--- a/src/main/resources/templates/admin/member-list.html
+++ b/src/main/resources/templates/admin/member-list.html
@@ -40,17 +40,17 @@
         </thead>
         <tbody>
             <tr th:each="member: ${members}">
-                <td th:text="${member.identifyNumber}" />
+                <td th:text="${member.id}" />
                 <td th:text="${member.email}" />
-                <td th:text="${member.authority}" />
+                <td th:text="${member.role}" />
                 <td>
-                    <form th:action="@{/admin/members/{id}(id=${member.identifyNumber})}"
+                    <form th:action="@{/admin/members/{id}(id=${member.id})}"
                           method="get" style="display:inline">
                         <button type="submit">View/Edit</button>
                     </form>
                 </td>
                 <td>
-                    <form th:action="@{/admin/members/{id}(id=${member.identifyNumber})}"
+                    <form th:action="@{/admin/members/{id}(id=${member.id})}"
                           method="post" style="display:inline"
                           onsubmit="return confirm('Are you sure to delete?');">
                         <input type="hidden" name="_method" value="delete" />

--- a/src/main/resources/templates/admin/member-list.html
+++ b/src/main/resources/templates/admin/member-list.html
@@ -16,19 +16,32 @@
 <body>
 <div class="container">
     <h2>회원목록</h2>
-    <div class="mb-3 d-flex justify-content-between align-items-center">
-        <a href="/admin/members/new" class="btn btn-success">Register New Member</a>
-        <form th:action="@{/admin/members}" method="get" class="form-inline">
-            <label for="pageSize" class="mr-2">Items per page:</label>
-            <select id="pageSize" name="size" class="form-control form-control-sm mr-2">
-                <option value="10" th:selected="${members.size == 10}">10</option>
-                <option value="20" th:selected="${members.size == 20}">20</option>
-                <option value="30" th:selected="${members.size == 30}">30</option>
-                <option value="40" th:selected="${members.size == 40}">40</option>
-                <option value="50" th:selected="${members.size == 50}">50</option>
-            </select>
+    <div class="mb-3 d-flex justify-content-between align-items-start">
+        <div>
+            <a href="/admin/members/new" class="btn btn-success">Register New Member</a>
+        </div>
+        <form th:action="@{/admin/members}" method="get" class="form-inline justify-content-end">
+            <div class="form-inline">
+                <label for="pageSize" class="mr-2">Items per page:</label>
+                <select id="pageSize" name="size" class="form-control form-control-sm mr-2">
+                    <option value="10" th:selected="${members.size == 10}">10</option>
+                    <option value="20" th:selected="${members.size == 20}">20</option>
+                    <option value="30" th:selected="${members.size == 30}">30</option>
+                    <option value="40" th:selected="${members.size == 40}">40</option>
+                    <option value="50" th:selected="${members.size == 50}">50</option>
+                </select>
+            </div>
+            <div class="form-inline">
+                <label for="sortOrder" class="mr-2">Sort by:</label>
+                <select id="sortOrder" name="sort" class="form-control form-control-sm mr-2">
+                    <option value="id,asc" th:selected="${members.sort == 'id: ASC'}">ID (Asc)</option>
+                    <option value="id,desc" th:selected="${members.sort == 'id: DESC'}">ID (Desc)</option>
+                    <option value="email,asc" th:selected="${members.sort == 'email: ASC'}">Email (Asc)</option>
+                    <option value="email,desc" th:selected="${members.sort == 'email: DESC'}">Email (Desc)</option>
+                </select>
+            </div>
             <input type="hidden" name="page" th:value="${members.number}">
-            <button type="submit" class="btn btn-info btn-sm">View</button>
+            <button type="submit" class="btn btn-info btn-sm ml-2">View</button>
         </form>
     </div>
     <table class="table table-bordered table-hover">

--- a/src/main/resources/templates/admin/product-form.html
+++ b/src/main/resources/templates/admin/product-form.html
@@ -3,72 +3,60 @@
 <head>
     <meta charset="UTF-8">
     <title>상품정보 작성</title>
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
     <style>
         body {
-            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            padding: 20px;
         }
-        a, button {
-            padding: 3px 6px;
-            border-radius: 4px;
-            text-decoration: none;
-            margin-right: 5px;
-            font-size: 14px;
-        }
-        button {
-            cursor: pointer;
-        }
-        a {
-            display: inline-block;
+        .container {
+            margin-top: 20px;
+            max-width: 600px;
         }
     </style>
 </head>
 <body>
-    <h1>상품정보 작성</h1>
-    <h2 th:if="${productId != null}" th:inline="text">- [[${productId}]]번 상품</h2>
-    <h2 th:if="${productId == null}">- 신규 상품</h2>
-    <h3 th:if="${productId != null and deleted}">❌상품이 삭제되어, 더이상 게시/수정할 수 없습니다. 현재 비공개 상태입니다.</h3>
-    <h3 th:if="${productId != null and !deleted}" th:text="${validated} ? '✅상품이 검증 완료되어, 현재 공개 상태입니다.' : '🛑상품명이 담당MD에 의해 검증되지 않은 상태입니다.'">안내문</h3>
-    <form th:if="${productId != null and !deleted}"
-          th:with="actionUrl='/admin/products/' + ${productId} + '?validated=' + ${!validated}"
-          th:action="@{${actionUrl}}"
-          method="post" style="display:inline">
+<div class="container">
+    <h1 class="mb-3">상품정보 작성</h1>
+    <h2 th:if="${productId != null}" class="h4" th:inline="text">- [[${productId}]]번 상품</h2>
+    <h2 th:if="${productId == null}" class="h4">- 신규 상품</h2>
+    <div th:if="${productId != null and deleted}" class="alert alert-danger">❌ 상품이 삭제되어, 더이상 게시/수정할 수 없습니다. 현재 비공개 상태입니다.</div>
+    <div th:if="${productId != null and !deleted}" th:class="${validated} ? 'alert alert-success' : 'alert alert-warning'" th:text="${validated} ? '✅상품이 검증 완료되어, 현재 공개 상태입니다.' : '🛑상품명이 담당MD에 의해 검증되지 않은 상태입니다.'"></div>
+
+    <form th:if="${productId != null and !deleted}" th:action="@{/admin/products/{id}(id=${productId}, validated=${!validated})}" method="post" style="display:inline">
         <input type="hidden" name="_method" value="patch" />
-        <button type="submit">Change Validated Status</button>
+        <button type="submit" class="btn btn-info mb-3">Change Validated Status</button>
     </form>
-    <form th:action="${productId == null} ? @{/admin/products} : @{/admin/products/{id}(id=${productId})}"
-          method="post"
-          th:object="${product}">
+
+    <form th:action="${productId == null} ? @{/admin/products} : @{/admin/products/{id}(id=${productId})}" method="post" th:object="${product}">
         <input type="hidden" name="_method" value="put" th:if="${productId != null}" />
-        <p>
-            <label>name:</label>
-            <input type="text" th:field="*{name}" />
-        </p>
-        <p>
-            <label>price:</label>
-            <input type="number" th:field="*{price}" />
-        </p>
-        <p>
-            <label>imageUrl:</label>
-            <input type="text" th:field="*{imageUrl}" />
-        </p>
-        <button type="submit" th:if="${productId == null}" >Create</button>
-        <button type="submit" th:if="${productId != null and !deleted}" >Apply Changes</button>
+        <div class="form-group">
+            <label for="name">Name:</label>
+            <input type="text" id="name" th:field="*{name}" class="form-control" />
+        </div>
+        <div class="form-group">
+            <label for="price">Price:</label>
+            <input type="number" id="price" th:field="*{price}" class="form-control" />
+        </div>
+        <div class="form-group">
+            <label for="imageUrl">Image URL:</label>
+            <input type="text" id="imageUrl" th:field="*{imageUrl}" class="form-control" />
+        </div>
+        <button type="submit" class="btn btn-primary" th:if="${productId == null}">Create</button>
+        <button type="submit" class="btn btn-primary" th:if="${productId != null and !deleted}">Apply Changes</button>
     </form>
-    <form th:if="${productId != null}"
-          th:action="@{/admin/products/{id}(id=${productId})}"
-          method="post" style="display:inline"
-          onsubmit="return confirm('Are you sure to delete?');">
-        <input type="hidden" name="_method" value="delete" />
-        <button type="submit">Delete</button>
-    </form>
-    <form action="/admin/products"
-          method="get" style="display:inline">
-        <button type="submit">Go to Product List</button>
-    </form>
-    <script th:if="${message}" th:inline="javascript">
-        /*<![CDATA[*/
-        alert([[${message}]]);
-        /*]]>*/
-    </script>
+
+    <div class="mt-3">
+        <form th:if="${productId != null}" th:action="@{/admin/products/{id}(id=${productId})}" method="post" style="display:inline" onsubmit="return confirm('Are you sure to delete?');">
+            <input type="hidden" name="_method" value="delete" />
+            <button type="submit" class="btn btn-danger">Delete</button>
+        </form>
+        <a href="/admin/products" class="btn btn-secondary">Go to Product List</a>
+    </div>
+</div>
+<script th:if="${message}" th:inline="javascript">
+    /*<![CDATA[*/
+    alert([[${message}]]);
+    /*]]>*/
+</script>
 </body>
 </html>

--- a/src/main/resources/templates/admin/product-list.html
+++ b/src/main/resources/templates/admin/product-list.html
@@ -3,81 +3,102 @@
 <head>
     <meta charset="UTF-8">
     <title>상품목록</title>
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
     <style>
         body {
-            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            padding: 20px;
         }
-        a, button {
-            padding: 3px 6px;
-            border-radius: 4px;
-            text-decoration: none;
-            margin-right: 5px;
-            font-size: 14px;
-        }
-        button {
-            cursor: pointer;
-        }
-        a {
-            display: inline-block;
+        .container {
+            margin-top: 20px;
         }
     </style>
 </head>
 <body>
+<div class="container">
     <h2>상품목록</h2>
-    <a th:if="${validated}"
-       th:href="@{/admin/products(validated=false)}"
-       style="background-color:black; color:white; border:1px solid black;">
-        Go to Non-Validated Product List
-    </a>
-    <a th:if="${!validated}"
-       th:href="@{/admin/products(validated=true)}"
-       style="background-color:black; color:white; border:1px solid black;">
-        Go to Validated Product List
-    </a>
-    <a href="/admin/products/new"
-       style="background-color:green; color:white; border:1px solid green;">
-        Create New Product
-    </a>
-    <table>
-        <thead>
-            <tr>
-                <th>id</th>
-                <th>image</th>
-                <th>name</th>
-                <th>price</th>
-                <th>View/Edit</th>
-                <th>Delete</th>
-            </tr>
+    <div class="mb-3 d-flex justify-content-between align-items-center">
+        <div>
+            <a th:if="${validated}"
+               th:href="@{/admin/products(validated=false)}"
+               class="btn btn-dark">
+                Go to Non-Validated Product List
+            </a>
+            <a th:if="${!validated}"
+               th:href="@{/admin/products(validated=true)}"
+               class="btn btn-dark">
+                Go to Validated Product List
+            </a>
+            <a href="/admin/products/new"
+               class="btn btn-success">
+                Create New Product
+            </a>
+        </div>
+        <form th:action="@{/admin/products}" method="get" class="form-inline">
+            <label for="pageSize" class="mr-2">Items per page:</label>
+            <select id="pageSize" name="size" class="form-control form-control-sm mr-2">
+                <option value="10" th:selected="${products.size == 10}">10</option>
+                <option value="20" th:selected="${products.size == 20}">20</option>
+                <option value="30" th:selected="${products.size == 30}">30</option>
+                <option value="40" th:selected="${products.size == 40}">40</option>
+                <option value="50" th:selected="${products.size == 50}">50</option>
+            </select>
+            <input type="hidden" name="page" th:value="${products.number}">
+            <input type="hidden" name="validated" th:value="${validated}">
+            <button type="submit" class="btn btn-info btn-sm">View</button>
+        </form>
+    </div>
+    <table class="table table-bordered table-hover">
+        <thead class="thead-light">
+        <tr>
+            <th>id</th>
+            <th>image</th>
+            <th>name</th>
+            <th>price</th>
+            <th>View/Edit</th>
+            <th>Delete</th>
+        </tr>
         </thead>
         <tbody>
-            <tr th:each="product: ${products}">
-                <td th:text="${product.id}" />
-                <td>
-                    <img th:src="${product.imageUrl}" width="50" />
-                </td>
-                <td th:text="${product.name}" />
-                <td th:text="${product.price}" />
-                <td>
-                    <form th:action="@{/admin/products/{id}(id=${product.id})}"
-                          method="get" style="display:inline">
-                        <button type="submit">View/Edit</button>
-                    </form>
-                </td>
-                <td>
-                    <form th:action="@{/admin/products/{id}(id=${product.id})}"
-                          method="post" style="display:inline"
-                          onsubmit="return confirm('Are you sure to delete?');">
-                        <input type="hidden" name="_method" value="delete" />
-                        <button type="submit">Delete</button>
-                    </form>
-                </td>
-            </tr>
+        <tr th:each="product: ${products.content}">
+            <td th:text="${product.id}" />
+            <td>
+                <img th:src="${product.imageUrl}" width="50" />
+            </td>
+            <td th:text="${product.name}" />
+            <td th:text="${product.price}" />
+            <td>
+                <a th:href="@{/admin/products/{id}(id=${product.id})}" class="btn btn-primary btn-sm">View/Edit</a>
+            </td>
+            <td>
+                <form th:action="@{/admin/products/{id}(id=${product.id})}"
+                      method="post" style="display:inline"
+                      onsubmit="return confirm('Are you sure to delete?');">
+                    <input type="hidden" name="_method" value="delete" />
+                    <button type="submit" class="btn btn-danger btn-sm">Delete</button>
+                </form>
+            </td>
+        </tr>
         </tbody>
     </table>
-    <script th:if="${message}" th:inline="javascript">
-        /*<![CDATA[*/
-        alert([[${message}]]);
-        /*]]>*/
-    </script>
+
+    <nav aria-label="Page navigation">
+        <ul class="pagination justify-content-center">
+            <li class="page-item" th:classappend="${products.first} ? 'disabled'">
+                <a class="page-link" th:href="@{/admin/products(validated=${validated}, page=${products.number - 1}, size=${products.size})}">Previous</a>
+            </li>
+            <li class="page-item" th:each="i : ${#numbers.sequence(0, products.totalPages - 1)}" th:classappend="${i == products.number} ? 'active'">
+                <a class="page-link" th:href="@{/admin/products(validated=${validated}, page=${i}, size=${products.size})}" th:text="${i + 1}"></a>
+            </li>
+            <li class="page-item" th:classappend="${products.last} ? 'disabled'">
+                <a class="page-link" th:href="@{/admin/products(validated=${validated}, page=${products.number + 1}, size=${products.size})}">Next</a>
+            </li>
+        </ul>
+    </nav>
+</div>
+<script th:if="${message}" th:inline="javascript">
+    /*<![CDATA[*/
+    alert([[${message}]]);
+    /*]]>*/
+</script>
 </body>
 </html>

--- a/src/main/resources/templates/admin/product-list.html
+++ b/src/main/resources/templates/admin/product-list.html
@@ -16,7 +16,7 @@
 <body>
 <div class="container">
     <h2>상품목록</h2>
-    <div class="mb-3 d-flex justify-content-between align-items-center">
+    <div class="mb-3 d-flex justify-content-between align-items-start">
         <div>
             <a th:if="${validated}"
                th:href="@{/admin/products(validated=false)}"
@@ -33,7 +33,7 @@
                 Create New Product
             </a>
         </div>
-        <form th:action="@{/admin/products}" method="get" class="form-inline">
+        <form th:action="@{/admin/products}" method="get" class="form-inline justify-content-end">
             <label for="pageSize" class="mr-2">Items per page:</label>
             <select id="pageSize" name="size" class="form-control form-control-sm mr-2">
                 <option value="10" th:selected="${products.size == 10}">10</option>
@@ -44,7 +44,16 @@
             </select>
             <input type="hidden" name="page" th:value="${products.number}">
             <input type="hidden" name="validated" th:value="${validated}">
-            <button type="submit" class="btn btn-info btn-sm">View</button>
+            <label for="sortOrder" class="mr-2">Sort by:</label>
+            <select id="sortOrder" name="sort" class="form-control form-control-sm mr-2">
+                <option value="id,asc" th:selected="${products.sort == 'id: ASC'}">ID (Asc)</option>
+                <option value="id,desc" th:selected="${products.sort == 'id: DESC'}">ID (Desc)</option>
+                <option value="name,asc" th:selected="${products.sort == 'name: ASC'}">Name (Asc)</option>
+                <option value="name,desc" th:selected="${products.sort == 'name: DESC'}">Name (Desc)</option>
+                <option value="price,asc" th:selected="${products.sort == 'price: ASC'}">Price (Asc)</option>
+                <option value="price,desc" th:selected="${products.sort == 'price: DESC'}">Price (Desc)</option>
+            </select>
+            <button type="submit" class="btn btn-info btn-sm align-self-start">View</button>
         </form>
     </div>
     <table class="table table-bordered table-hover">
@@ -61,15 +70,15 @@
         <tbody>
         <tr th:each="product: ${products.content}">
             <td th:text="${product.id}" />
-            <td>
-                <img th:src="${product.imageUrl}" width="50" />
+            <td class="text-center p-0 align-middle">
+                <img th:src="${product.imageUrl}" height="50" />
             </td>
             <td th:text="${product.name}" />
             <td th:text="${product.price}" />
-            <td>
+            <td class="text-center align-middle">
                 <a th:href="@{/admin/products/{id}(id=${product.id})}" class="btn btn-primary btn-sm">View/Edit</a>
             </td>
-            <td>
+            <td class="text-center align-middle">
                 <form th:action="@{/admin/products/{id}(id=${product.id})}"
                       method="post" style="display:inline"
                       onsubmit="return confirm('Are you sure to delete?');">

--- a/src/main/resources/templates/error/custom-error.html
+++ b/src/main/resources/templates/error/custom-error.html
@@ -21,7 +21,7 @@
 <div class="container-fluid text-center">
     <h1 class="display-4">오류가 발생했습니다</h1>
     <p class="lead" th:text="${errorMessage}">여기에 오류 메시지가 표시됩니다.</p>
-    <a href="/admin/products" class="btn btn-success">상품 목록으로 돌아가기</a>
+    <a th:href="${prevPage}" class="btn btn-success">이전 페이지로 돌아가기</a>
 </div>
 </body>
 </html>

--- a/src/main/resources/templates/error/custom-error.html
+++ b/src/main/resources/templates/error/custom-error.html
@@ -21,7 +21,11 @@
 <div class="container-fluid text-center">
     <h1 class="display-4">오류가 발생했습니다</h1>
     <p class="lead" th:text="${errorMessage}">여기에 오류 메시지가 표시됩니다.</p>
-    <a th:href="${prevPage}" class="btn btn-success">이전 페이지로 돌아가기</a>
+    <div class="inline-block">
+        <a th:href="${prevPage}" class="btn btn-success">이전 페이지로 돌아가기</a>
+        <a th:href="@{/admin}" class="btn btn-primary">관리자 대시보드로 이동</a>
+        <a th:href="${mainPage}" class="btn btn-secondary">리스트로 이동</a>
+    </div>
 </div>
 </body>
 </html>

--- a/src/main/resources/templates/error/custom-error.html
+++ b/src/main/resources/templates/error/custom-error.html
@@ -3,15 +3,25 @@
 <head>
     <meta charset="UTF-8">
     <title>오류 발생</title>
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
+    <style>
+        body, html {
+            height: 100%;
+        }
+        .container-fluid {
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+            align-items: center;
+            height: 100%;
+        }
+    </style>
 </head>
 <body>
-<div style="width: 100%; height: 100vh; display: flex; flex-direction: column; justify-content: center; align-items: center; text-align: center;">
-    <h1>오류가 발생했습니다</h1>
-    <p th:text="${errorMessage}">여기에 오류 메시지가 표시됩니다.</p>
-    <a href="/admin/products"
-       style="display:inline-block; padding:3px 6px; background-color:green; color:white; border-radius:4px; text-decoration: none; border:1px solid green;">
-        상품 목록으로 돌아가기
-    </a>
+<div class="container-fluid text-center">
+    <h1 class="display-4">오류가 발생했습니다</h1>
+    <p class="lead" th:text="${errorMessage}">여기에 오류 메시지가 표시됩니다.</p>
+    <a href="/admin/products" class="btn btn-success">상품 목록으로 돌아가기</a>
 </div>
 </body>
 </html>

--- a/src/test/java/gift/controller/ProductAdminPageControllerTest.java
+++ b/src/test/java/gift/controller/ProductAdminPageControllerTest.java
@@ -47,6 +47,7 @@ class ProductAdminPageControllerTest {
         Product mockProduct = new Product(
             1L, "아이스 카페 아메리카노 T", 4700,
             "https://st.kakaocdn.net/product/gift/product/20231010111814_9a667f9eccc943648797925498bdd8a3.jpg",
+            false,
             false
         );
         when(productService.createProduct(any(), any(), any()))
@@ -66,7 +67,8 @@ class ProductAdminPageControllerTest {
         Product mockProduct = new Product(
             1L, "&%&각하오커피&%&", -5000,
             "https://st.kakaocdn.net/product/gift/product/20231010111814_9a667f9eccc943648797925498bdd8a3.jpg",
-            false // validated
+            false,
+            false
         );
         when(productService.createProduct(any(), any(), any()))
             .thenReturn(mockProduct);
@@ -93,7 +95,7 @@ class ProductAdminPageControllerTest {
     @Test
     void 유효한_상품_조회_시_상품상세페이지() throws Exception {
         Product mockProduct = new Product(1L, "각하오커피", 7800,
-            "https://...", false);
+            "https://...", false, false);
         when(productService.getProductWhetherDeletedById(1L)).thenReturn(mockProduct);
 
         mockMvc.perform(get("/admin/products/1"))
@@ -103,7 +105,7 @@ class ProductAdminPageControllerTest {
 
     @Test
     void 유효한_상품_수정_시_리다이렉션() throws Exception {
-        Product updated = new Product(1L, "각하오 커피", 7800, "https://...", false);
+        Product updated = new Product(1L, "각하오 커피", 7800, "https://...", false, false);
         when(productService.updateProductById(eq(1L), any(), any(), any()))
                 .thenReturn(updated);
 
@@ -118,7 +120,7 @@ class ProductAdminPageControllerTest {
 
     @Test
     void 유효하지_않은_상품_수정_시_상품상세페이지() throws Exception {
-        Product existing = new Product(1L, "각하오 커피", 7800, "https://...", false);
+        Product existing = new Product(1L, "각하오 커피", 7800, "https://...", false, false);
         when(productService.getProductById(1L)).thenReturn(existing);
         when(productService.getProductWhetherDeletedById(1L)).thenReturn(existing);
 

--- a/src/test/java/gift/controller/ProductAdminPageControllerTest.java
+++ b/src/test/java/gift/controller/ProductAdminPageControllerTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.data.domain.Page;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -30,6 +31,7 @@ class ProductAdminPageControllerTest {
 
     @Test
     void 상품목록_조회_시_상품목록페이지() throws Exception {
+        when(productService.getProductList(any(), any())).thenReturn(Page.empty());
         mockMvc.perform(get("/admin/products"))
             .andExpect(view().name("admin/product-list"))
             .andExpect(model().attributeExists("products"));

--- a/src/test/java/gift/e2e/ProductE2ETest.java
+++ b/src/test/java/gift/e2e/ProductE2ETest.java
@@ -1,6 +1,8 @@
 package gift.e2e;
 
 import gift.dto.CreateProductRequest;
+import gift.dto.PageResponse;
+import gift.dto.ProductResponse;
 import gift.dto.UpdateProductRequest;
 import gift.entity.Member;
 import gift.entity.Product;
@@ -74,15 +76,15 @@ public class ProductE2ETest {
                     4700,
                     "https://st.kakaocdn.net/product/gift/product/20231010111814_9a667f9eccc943648797925498bdd8a3.jpg"
             );
-            ResponseEntity<Product> response = restClient.post()
+            ResponseEntity<ProductResponse> response = restClient.post()
                     .uri(url)
                     .header("Authorization", "Bearer " + mdToken)
                     .body(requestDto)
                     .retrieve()
-                    .toEntity(Product.class);
+                    .toEntity(ProductResponse.class);
             assertAll(
                     () -> assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED),
-                    () -> assertThat(response.getBody().getName()).isEqualTo("아이스 카페 아메리카노 T")
+                    () -> assertThat(response.getBody().name()).isEqualTo("아이스 카페 아메리카노 T")
             );
         }
 
@@ -110,14 +112,14 @@ public class ProductE2ETest {
         @DisplayName("GET /api/products/{id} - 유효한 조회 시 200 OK")
         void 유효한_조회_시_200_OK() {
             String url = baseUrl + port + "/api/products/" + savedProduct.getId();
-            ResponseEntity<Product> response = restClient.get()
+            ResponseEntity<ProductResponse> response = restClient.get()
                     .uri(url)
                     .header("Authorization", "Bearer " + mdToken)
                     .retrieve()
-                    .toEntity(Product.class);
+                    .toEntity(ProductResponse.class);
             assertAll(
                     () -> assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK),
-                    () -> assertThat(response.getBody().getName()).isEqualTo("Initial Product")
+                    () -> assertThat(response.getBody().name()).isEqualTo("Initial Product")
             );
         }
 
@@ -149,16 +151,16 @@ public class ProductE2ETest {
                     7800,
                     null
             );
-            ResponseEntity<Product> response = restClient.patch()
+            ResponseEntity<ProductResponse> response = restClient.patch()
                     .uri(url)
                     .header("Authorization", "Bearer " + mdToken)
                     .body(patchDto)
                     .retrieve()
-                    .toEntity(Product.class);
+                    .toEntity(ProductResponse.class);
             assertAll(
                     () -> assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK),
-                    () -> assertThat(response.getBody().getName()).isEqualTo("각하오 커피"),
-                    () -> assertThat(response.getBody().getImageUrl()).isNotNull()
+                    () -> assertThat(response.getBody().name()).isEqualTo("각하오 커피"),
+                    () -> assertThat(response.getBody().imageUrl()).isNotNull()
             );
         }
 
@@ -188,15 +190,15 @@ public class ProductE2ETest {
     @DisplayName("GET /api/products - 리스트 조회 시 200 OK")
     void 리스트_조회_시_200_OK() {
         String url = baseUrl + port + "/api/products";
-        ResponseEntity<RestPage<Product>> response = restClient.get()
+        ResponseEntity<PageResponse<ProductResponse>> response = restClient.get()
                 .uri(url)
                 .header("Authorization", "Bearer " + mdToken)
                 .retrieve()
-                .toEntity(new ParameterizedTypeReference<RestPage<Product>>() {});
+                .toEntity(new ParameterizedTypeReference<>() {});
 
         assertAll(
                 () -> assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK),
-                () -> assertThat(response.getBody().getContent().size()).isNotZero()
+                () -> assertThat(response.getBody().content().size()).isNotZero()
         );
     }
 

--- a/src/test/java/gift/e2e/ProductE2ETest.java
+++ b/src/test/java/gift/e2e/ProductE2ETest.java
@@ -54,7 +54,7 @@ public class ProductE2ETest {
         restClient = RestClient.create();
         Member md = memberRepository.save(new Member(null, "md@example.com", "mdpassword123456789", Role.ROLE_MD));
         mdToken = jwtTokenProvider.createToken(md);
-        savedProduct = productRepository.save(new Product(null, "Initial Product", 10000, "initial.jpg", true));
+        savedProduct = productRepository.save(new Product(null, "Initial Product", 10000, "initial.jpg", true, false));
     }
 
     @AfterEach

--- a/src/test/java/gift/e2e/ProductE2ETest.java
+++ b/src/test/java/gift/e2e/ProductE2ETest.java
@@ -8,6 +8,7 @@ import gift.entity.Role;
 import gift.repository.MemberRepository;
 import gift.repository.ProductRepository;
 import gift.token.JwtTokenProvider;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -18,11 +19,8 @@ import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.junit.jupiter.api.AfterEach;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestClient;
-
-import java.util.List;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
@@ -190,15 +188,15 @@ public class ProductE2ETest {
     @DisplayName("GET /api/products - 리스트 조회 시 200 OK")
     void 리스트_조회_시_200_OK() {
         String url = baseUrl + port + "/api/products";
-        ResponseEntity<List<Product>> response = restClient.get()
+        ResponseEntity<RestPage<Product>> response = restClient.get()
                 .uri(url)
                 .header("Authorization", "Bearer " + mdToken)
                 .retrieve()
-                .toEntity(new ParameterizedTypeReference<List<Product>>() {});
+                .toEntity(new ParameterizedTypeReference<RestPage<Product>>() {});
 
         assertAll(
                 () -> assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK),
-                () -> assertThat(response.getBody().size()).isNotZero()
+                () -> assertThat(response.getBody().getContent().size()).isNotZero()
         );
     }
 

--- a/src/test/java/gift/e2e/RestPage.java
+++ b/src/test/java/gift/e2e/RestPage.java
@@ -1,0 +1,34 @@
+package gift.e2e;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+public class RestPage<T> extends PageImpl<T> {
+    @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+    public RestPage(@JsonProperty("content") List<T> content,
+                    @JsonProperty("number") int number,
+                    @JsonProperty("size") int size,
+                    @JsonProperty("totalElements") Long totalElements,
+                    @JsonProperty("pageable") JsonNode pageable,
+                    @JsonProperty("last") boolean last,
+                    @JsonProperty("totalPages") int totalPages,
+                    @JsonProperty("sort") JsonNode sort,
+                    @JsonProperty("first") boolean first,
+                    @JsonProperty("numberOfElements") int numberOfElements) {
+        super(content, PageRequest.of(number, size), totalElements);
+    }
+
+    public RestPage(List<T> content, Pageable pageable, long total) {
+        super(content, pageable, total);
+    }
+
+    public RestPage(List<T> content) {
+        super(content);
+    }
+}

--- a/src/test/java/gift/e2e/WishE2ETest.java
+++ b/src/test/java/gift/e2e/WishE2ETest.java
@@ -1,6 +1,7 @@
 package gift.e2e;
 
 import gift.dto.AddWishItemRequest;
+import gift.dto.PageResponse;
 import gift.dto.WishItemResponse;
 import gift.entity.Member;
 import gift.entity.Product;
@@ -74,7 +75,7 @@ public class WishE2ETest {
         void 위시리스트_조회_시_200_OK() {
             wishRepository.save(new Wish(savedUser, savedProduct1));
 
-            ResponseEntity<RestPage<WishItemResponse>> response = restClient.get()
+            ResponseEntity<PageResponse<WishItemResponse>> response = restClient.get()
                     .uri(url)
                     .header("Authorization", "Bearer " + userToken)
                     .retrieve()
@@ -82,8 +83,8 @@ public class WishE2ETest {
 
             assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
             assertThat(response.getBody()).isNotNull();
-            assertThat(response.getBody().getContent().size()).isEqualTo(1);
-            assertThat(response.getBody().getContent().get(0).productName()).isEqualTo("Product 1");
+            assertThat(response.getBody().content().size()).isEqualTo(1);
+            assertThat(response.getBody().content().get(0).productName()).isEqualTo("Product 1");
         }
 
         @Test

--- a/src/test/java/gift/e2e/WishE2ETest.java
+++ b/src/test/java/gift/e2e/WishE2ETest.java
@@ -55,8 +55,8 @@ public class WishE2ETest {
         savedUser = memberRepository.save(new Member(null, "user@example.com", "password123456789", Role.ROLE_USER));
         userToken = jwtTokenProvider.createToken(savedUser);
 
-        savedProduct1 = productRepository.save(new Product(null, "Product 1", 1000, "prod1.jpg", true));
-        savedProduct2 = productRepository.save(new Product(null, "Product 2", 2000, "prod2.jpg", true));
+        savedProduct1 = productRepository.save(new Product(null, "Product 1", 1000, "prod1.jpg", true, false));
+        savedProduct2 = productRepository.save(new Product(null, "Product 2", 2000, "prod2.jpg", true, false));
     }
 
     @AfterEach
@@ -74,7 +74,7 @@ public class WishE2ETest {
         @Test
         @DisplayName("GET /api/wishes - 위시리스트 조회 시 200 OK")
         void 위시리스트_조회_시_200_OK() {
-            wishRepository.save(new Wish(savedUser.getId(), savedProduct1));
+            wishRepository.save(new Wish(savedUser, savedProduct1));
 
             ResponseEntity<List<WishItemResponse>> response = restClient.get()
                     .uri(url)
@@ -138,7 +138,7 @@ public class WishE2ETest {
         @DisplayName("POST /api/wishes - 이미 존재하는 아이템 추가 시 409 CONFLICT")
         void 이미_존재하는_아이템_추가_시_409_CONFLICT() {
             // 첫 번째 추가
-            wishRepository.save(new Wish(savedUser.getId(), savedProduct1));
+            wishRepository.save(new Wish(savedUser, savedProduct1));
             AddWishItemRequest request = new AddWishItemRequest(savedProduct1.getId());
 
             // 두 번째 추가 시도
@@ -170,7 +170,7 @@ public class WishE2ETest {
         @Test
         @DisplayName("DELETE /api/wishes/{wishItemId} - 유효한 아이템 삭제 시 204 NO_CONTENT")
         void 유효한_아이템_삭제_시_204_NO_CONTENT() {
-            Wish wish = wishRepository.save(new Wish(savedUser.getId(), savedProduct1));
+            Wish wish = wishRepository.save(new Wish(savedUser, savedProduct1));
 
             ResponseEntity<Void> response = restClient.delete()
                     .uri(url + "/" + wish.getId())
@@ -196,7 +196,7 @@ public class WishE2ETest {
         @DisplayName("DELETE /api/wishes/{wishItemId} - 다른 사용자의 아이템 삭제 시 404 NOT_FOUND")
         void 다른_사용자의_아이템_삭제_시_404_NOT_FOUND() {
             Member otherUser = memberRepository.save(new Member(null, "", "", Role.ROLE_USER));
-            Wish otherUsersWish = wishRepository.save(new Wish(otherUser.getId(), savedProduct1));
+            Wish otherUsersWish = wishRepository.save(new Wish(otherUser, savedProduct1));
 
 
             assertThatExceptionOfType(HttpClientErrorException.NotFound.class)

--- a/src/test/java/gift/e2e/WishE2ETest.java
+++ b/src/test/java/gift/e2e/WishE2ETest.java
@@ -17,8 +17,6 @@ import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.test.context.jdbc.Sql;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestClient;
 
@@ -76,7 +74,7 @@ public class WishE2ETest {
         @Test
         @DisplayName("GET /api/wishes - 위시리스트 조회 시 200 OK")
         void 위시리스트_조회_시_200_OK() {
-            wishRepository.save(new WishItem(savedUser.getIdentifyNumber(), savedProduct1));
+            wishRepository.save(new WishItem(savedUser.getId(), savedProduct1));
 
             ResponseEntity<List<WishItemResponse>> response = restClient.get()
                     .uri(url)
@@ -140,7 +138,7 @@ public class WishE2ETest {
         @DisplayName("POST /api/wishes - 이미 존재하는 아이템 추가 시 409 CONFLICT")
         void 이미_존재하는_아이템_추가_시_409_CONFLICT() {
             // 첫 번째 추가
-            wishRepository.save(new WishItem(savedUser.getIdentifyNumber(), savedProduct1));
+            wishRepository.save(new WishItem(savedUser.getId(), savedProduct1));
             AddWishItemRequest request = new AddWishItemRequest(savedProduct1.getId());
 
             // 두 번째 추가 시도
@@ -172,7 +170,7 @@ public class WishE2ETest {
         @Test
         @DisplayName("DELETE /api/wishes/{wishItemId} - 유효한 아이템 삭제 시 204 NO_CONTENT")
         void 유효한_아이템_삭제_시_204_NO_CONTENT() {
-            WishItem wishItem = wishRepository.save(new WishItem(savedUser.getIdentifyNumber(), savedProduct1));
+            WishItem wishItem = wishRepository.save(new WishItem(savedUser.getId(), savedProduct1));
 
             ResponseEntity<Void> response = restClient.delete()
                     .uri(url + "/" + wishItem.getId())
@@ -198,7 +196,7 @@ public class WishE2ETest {
         @DisplayName("DELETE /api/wishes/{wishItemId} - 다른 사용자의 아이템 삭제 시 404 NOT_FOUND")
         void 다른_사용자의_아이템_삭제_시_404_NOT_FOUND() {
             Member otherUser = memberRepository.save(new Member(null, "", "", Role.ROLE_USER));
-            WishItem otherUsersWishItem = wishRepository.save(new WishItem(otherUser.getIdentifyNumber(), savedProduct1));
+            WishItem otherUsersWishItem = wishRepository.save(new WishItem(otherUser.getId(), savedProduct1));
 
 
             assertThatExceptionOfType(HttpClientErrorException.NotFound.class)

--- a/src/test/java/gift/e2e/WishE2ETest.java
+++ b/src/test/java/gift/e2e/WishE2ETest.java
@@ -20,8 +20,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestClient;
 
-import java.util.List;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
@@ -76,7 +74,7 @@ public class WishE2ETest {
         void 위시리스트_조회_시_200_OK() {
             wishRepository.save(new Wish(savedUser, savedProduct1));
 
-            ResponseEntity<List<WishItemResponse>> response = restClient.get()
+            ResponseEntity<RestPage<WishItemResponse>> response = restClient.get()
                     .uri(url)
                     .header("Authorization", "Bearer " + userToken)
                     .retrieve()
@@ -84,8 +82,8 @@ public class WishE2ETest {
 
             assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
             assertThat(response.getBody()).isNotNull();
-            assertThat(response.getBody().size()).isEqualTo(1);
-            assertThat(response.getBody().get(0).productName()).isEqualTo("Product 1");
+            assertThat(response.getBody().getContent().size()).isEqualTo(1);
+            assertThat(response.getBody().getContent().get(0).productName()).isEqualTo("Product 1");
         }
 
         @Test
@@ -95,7 +93,7 @@ public class WishE2ETest {
                     .isThrownBy(() -> restClient.get()
                             .uri(url)
                             .retrieve()
-                            .toEntity(new ParameterizedTypeReference<List<Wish>>() {}));
+                            .toEntity(new ParameterizedTypeReference<RestPage<Wish>>() {}));
         }
     }
 
@@ -158,7 +156,7 @@ public class WishE2ETest {
                     .isThrownBy(() -> restClient.get()
                             .uri(url)
                             .retrieve()
-                            .toEntity(new ParameterizedTypeReference<List<Wish>>() {}));
+                            .toEntity(new ParameterizedTypeReference<RestPage<Wish>>() {}));
         }
     }
 
@@ -214,7 +212,7 @@ public class WishE2ETest {
                     .isThrownBy(() -> restClient.get()
                             .uri(url)
                             .retrieve()
-                            .toEntity(new ParameterizedTypeReference<List<Wish>>() {}));
+                            .toEntity(new ParameterizedTypeReference<RestPage<Wish>>() {}));
         }
     }
 }

--- a/src/test/java/gift/e2e/WishE2ETest.java
+++ b/src/test/java/gift/e2e/WishE2ETest.java
@@ -5,7 +5,7 @@ import gift.dto.WishItemResponse;
 import gift.entity.Member;
 import gift.entity.Product;
 import gift.entity.Role;
-import gift.entity.WishItem;
+import gift.entity.Wish;
 import gift.repository.MemberRepository;
 import gift.repository.ProductRepository;
 import gift.repository.WishRepository;
@@ -74,7 +74,7 @@ public class WishE2ETest {
         @Test
         @DisplayName("GET /api/wishes - 위시리스트 조회 시 200 OK")
         void 위시리스트_조회_시_200_OK() {
-            wishRepository.save(new WishItem(savedUser.getId(), savedProduct1));
+            wishRepository.save(new Wish(savedUser.getId(), savedProduct1));
 
             ResponseEntity<List<WishItemResponse>> response = restClient.get()
                     .uri(url)
@@ -95,7 +95,7 @@ public class WishE2ETest {
                     .isThrownBy(() -> restClient.get()
                             .uri(url)
                             .retrieve()
-                            .toEntity(new ParameterizedTypeReference<List<WishItem>>() {}));
+                            .toEntity(new ParameterizedTypeReference<List<Wish>>() {}));
         }
     }
 
@@ -138,7 +138,7 @@ public class WishE2ETest {
         @DisplayName("POST /api/wishes - 이미 존재하는 아이템 추가 시 409 CONFLICT")
         void 이미_존재하는_아이템_추가_시_409_CONFLICT() {
             // 첫 번째 추가
-            wishRepository.save(new WishItem(savedUser.getId(), savedProduct1));
+            wishRepository.save(new Wish(savedUser.getId(), savedProduct1));
             AddWishItemRequest request = new AddWishItemRequest(savedProduct1.getId());
 
             // 두 번째 추가 시도
@@ -158,7 +158,7 @@ public class WishE2ETest {
                     .isThrownBy(() -> restClient.get()
                             .uri(url)
                             .retrieve()
-                            .toEntity(new ParameterizedTypeReference<List<WishItem>>() {}));
+                            .toEntity(new ParameterizedTypeReference<List<Wish>>() {}));
         }
     }
 
@@ -170,10 +170,10 @@ public class WishE2ETest {
         @Test
         @DisplayName("DELETE /api/wishes/{wishItemId} - 유효한 아이템 삭제 시 204 NO_CONTENT")
         void 유효한_아이템_삭제_시_204_NO_CONTENT() {
-            WishItem wishItem = wishRepository.save(new WishItem(savedUser.getId(), savedProduct1));
+            Wish wish = wishRepository.save(new Wish(savedUser.getId(), savedProduct1));
 
             ResponseEntity<Void> response = restClient.delete()
-                    .uri(url + "/" + wishItem.getId())
+                    .uri(url + "/" + wish.getId())
                     .header("Authorization", "Bearer " + userToken)
                     .retrieve()
                     .toEntity(Void.class);
@@ -196,12 +196,12 @@ public class WishE2ETest {
         @DisplayName("DELETE /api/wishes/{wishItemId} - 다른 사용자의 아이템 삭제 시 404 NOT_FOUND")
         void 다른_사용자의_아이템_삭제_시_404_NOT_FOUND() {
             Member otherUser = memberRepository.save(new Member(null, "", "", Role.ROLE_USER));
-            WishItem otherUsersWishItem = wishRepository.save(new WishItem(otherUser.getId(), savedProduct1));
+            Wish otherUsersWish = wishRepository.save(new Wish(otherUser.getId(), savedProduct1));
 
 
             assertThatExceptionOfType(HttpClientErrorException.NotFound.class)
                     .isThrownBy(() -> restClient.delete()
-                            .uri(url + "/" + otherUsersWishItem.getId())
+                            .uri(url + "/" + otherUsersWish.getId())
                             .header("Authorization", "Bearer " + userToken)
                             .retrieve()
                             .toEntity(Void.class));
@@ -214,7 +214,7 @@ public class WishE2ETest {
                     .isThrownBy(() -> restClient.get()
                             .uri(url)
                             .retrieve()
-                            .toEntity(new ParameterizedTypeReference<List<WishItem>>() {}));
+                            .toEntity(new ParameterizedTypeReference<List<Wish>>() {}));
         }
     }
 }

--- a/src/test/java/gift/repository/MemberRepositoryTest.java
+++ b/src/test/java/gift/repository/MemberRepositoryTest.java
@@ -48,7 +48,7 @@ class MemberRepositoryTest {
             );
             Member savedMember = memberRepository.save(exampleMember);
             assertAll(
-                    () -> assertThat(savedMember.getIdentifyNumber()).isNotNull(),
+                    () -> assertThat(savedMember.getId()).isNotNull(),
                     () -> assertTrue(memberDetailsEquals(savedMember, exampleMember))
             );
         }
@@ -94,13 +94,13 @@ class MemberRepositoryTest {
         @Test
         @DisplayName("존재하는 멤버의 식별번호로 조회 시 멤버 반환")
         void 존재하는_멤버의_식별번호로_조회_시_멤버반환() {
-            assertThat(memberRepository.findByIdentifyNumber(existingMember.getIdentifyNumber())).isPresent();
+            assertThat(memberRepository.findById(existingMember.getId())).isPresent();
         }
 
         @Test
         @DisplayName("존재하지 않는 식별번호로 조회 시 빈 Optional 반환")
         void 존재하지_않는_식별번호로_조회_시_빈Optional반환() {
-            assertThat(memberRepository.findByIdentifyNumber(500L)).isEmpty();
+            assertThat(memberRepository.findById(500L)).isEmpty();
         }
     }
 
@@ -126,21 +126,25 @@ class MemberRepositoryTest {
     class deleteByIdentifyNumberTests {
 
         @Test
-        @DisplayName("존재하는 멤버의 식별번호로 삭제 시 true 반환")
-        void 존재하는_멤버의_식별번호로_삭제_시_true반환() {
-            assertThat(memberRepository.deleteByIdentifyNumber(existingMember.getIdentifyNumber())).isEqualTo(1);
+        @DisplayName("존재하는 멤버의 식별번호로 삭제 시 삭제")
+        void 존재하는_멤버의_식별번호로_삭제_시_삭제() {
+            assertThat(memberRepository.findById(existingMember.getId())).isPresent();
+            memberRepository.deleteById(existingMember.getId());
+            assertThat(memberRepository.findById(existingMember.getId())).isEmpty();
         }
 
         @Test
-        @DisplayName("존재하지 않는 식별번호로 삭제 시 false 반환")
-        void 존재하지_않는_식별번호로_삭제_시_false반환() {
-            assertThat(memberRepository.deleteByIdentifyNumber(500L)).isEqualTo(0);
+        @DisplayName("존재하지 않는 식별번호로 삭제 시 미삭제")
+        void 존재하지_않는_식별번호로_삭제_시_미삭제() {
+            assertThat(memberRepository.findById(existingMember.getId())).isPresent();
+            memberRepository.deleteById(500L);
+            assertThat(memberRepository.findById(existingMember.getId())).isPresent();
         }
     }
 
     private boolean memberDetailsEquals(Member member1, Member member2) {
         return member1.getEmail().equals(member2.getEmail())
             && member1.getPassword().equals(member2.getPassword())
-            && member1.getAuthority().equals(member2.getAuthority());
+            && member1.getRole().equals(member2.getRole());
     }
 }

--- a/src/test/java/gift/repository/ProductRepositoryTest.java
+++ b/src/test/java/gift/repository/ProductRepositoryTest.java
@@ -113,24 +113,24 @@ class ProductRepositoryTest {
         @Test
         @DisplayName("deleted가 false이며 validated가 true인 상품 목록 조회 시 정상 반환")
         void deleted가_false이며_validated가_true인_상품_목록_조회_시_정상반환() {
-            assertThat(productRepository.findAllByDeletedIsFalseAndValidated(true)).hasSize(1);
-            assertThat(productRepository.findAllByDeletedIsFalseAndValidated(false)).hasSize(0);
+            assertThat(productRepository.findAllByDeletedIsFalseAndValidated(true, null)).hasSize(1);
+            assertThat(productRepository.findAllByDeletedIsFalseAndValidated(false, null)).hasSize(0);
         }
 
         @Test
         @DisplayName("validated가 false인 상품은 목록에 포함되지 않음")
         void deleted가_false이며_validated가_false인_상품_추가_후_상품_목록_조회_시_정상반환() {
             existingProduct.setValidated(false);
-            assertThat(productRepository.findAllByDeletedIsFalseAndValidated(true)).hasSize(0);
-            assertThat(productRepository.findAllByDeletedIsFalseAndValidated(false)).hasSize(1);
+            assertThat(productRepository.findAllByDeletedIsFalseAndValidated(true, null)).hasSize(0);
+            assertThat(productRepository.findAllByDeletedIsFalseAndValidated(false, null)).hasSize(1);
         }
 
         @Test
         @DisplayName("deleted가 true인 상품은 목록에 포함되지 않음")
         void deleted가_true인_상품은_목록에_포함되지_않음() {
             existingProduct.setDeleted(true);
-            assertThat(productRepository.findAllByDeletedIsFalseAndValidated(true)).hasSize(0);
-            assertThat(productRepository.findAllByDeletedIsFalseAndValidated(false)).hasSize(0);
+            assertThat(productRepository.findAllByDeletedIsFalseAndValidated(true, null)).hasSize(0);
+            assertThat(productRepository.findAllByDeletedIsFalseAndValidated(false, null)).hasSize(0);
         }
 
     }

--- a/src/test/java/gift/repository/WishRepositoryTest.java
+++ b/src/test/java/gift/repository/WishRepositoryTest.java
@@ -3,7 +3,7 @@ package gift.repository;
 import gift.entity.Member;
 import gift.entity.Product;
 import gift.entity.Role;
-import gift.entity.WishItem;
+import gift.entity.Wish;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
@@ -54,23 +54,23 @@ class WishRepositoryTest {
     }
 
     @Nested
-    @DisplayName("WishItem save() - 위시 아이템 생성 테스트")
+    @DisplayName("Wish save() - 위시 아이템 생성 테스트")
     class SaveTests {
 
         @Test
         @DisplayName("정상적인 위시 아이템 데이터 삽입")
         void 정상적인_위시_아이템_삽입_시_정상반환() {
-            WishItem wishItem = new WishItem(
+            Wish wish = new Wish(
                     null,
                     existingMember,
                     existingProduct,
                     LocalDateTime.now()
             );
-            WishItem savedWishItem = wishRepository.save(wishItem);
+            Wish savedWish = wishRepository.save(wish);
             assertAll(
-                () -> assertThat(savedWishItem.getId()).isNotNull(),
-                () -> assertThat(savedWishItem.getMember().getId()).isEqualTo(existingMember.getId()),
-                () -> assertThat(savedWishItem.getProduct().getId()).isEqualTo(existingProduct.getId())
+                () -> assertThat(savedWish.getId()).isNotNull(),
+                () -> assertThat(savedWish.getMember().getId()).isEqualTo(existingMember.getId()),
+                () -> assertThat(savedWish.getProduct().getId()).isEqualTo(existingProduct.getId())
             );
         }
 
@@ -79,14 +79,14 @@ class WishRepositoryTest {
         void 널_값이_포함된_위시_아이템_삽입_시_예외_발생() {
             // id는 항상 null인 상태로 삽입되어야 함
 
-            WishItem allNullWishItem = new WishItem(null, null, null, null);
-            Assertions.assertThrows(DataIntegrityViolationException.class, () -> wishRepository.save(allNullWishItem));
+            Wish allNullWish = new Wish(null, null, null, null);
+            Assertions.assertThrows(DataIntegrityViolationException.class, () -> wishRepository.save(allNullWish));
 
-            WishItem memberNullWishItem = new WishItem(null, null, existingProduct, LocalDateTime.now());
-            Assertions.assertThrows(DataIntegrityViolationException.class, () -> wishRepository.save(memberNullWishItem));
+            Wish memberNullWish = new Wish(null, null, existingProduct, LocalDateTime.now());
+            Assertions.assertThrows(DataIntegrityViolationException.class, () -> wishRepository.save(memberNullWish));
 
-            WishItem productNullWishItem = new WishItem(null, existingMember, null, LocalDateTime.now());
-            Assertions.assertThrows(DataIntegrityViolationException.class, () -> wishRepository.save(productNullWishItem));
+            Wish productNullWish = new Wish(null, existingMember, null, LocalDateTime.now());
+            Assertions.assertThrows(DataIntegrityViolationException.class, () -> wishRepository.save(productNullWish));
         }
 
         @Test
@@ -95,45 +95,45 @@ class WishRepositoryTest {
             // 존재하지 않는 member / product로 삽입 시도
             Member nonExistentMember = new Member(999L, null, null, null);
             Product nonExistentProduct = new Product(999L, null, null, null, null, null);
-            WishItem wishItem = new WishItem(
+            Wish wish = new Wish(
                   null,
                     nonExistentMember,
                     nonExistentProduct,
                     LocalDateTime.now()
             );
-            Assertions.assertThrows(DataIntegrityViolationException.class, () -> wishRepository.save(wishItem));
+            Assertions.assertThrows(DataIntegrityViolationException.class, () -> wishRepository.save(wish));
         }
     }
 
     @Nested
-    @DisplayName("List<WishItem> findAllByMemberId(Long memberId) - 위시 리스트 조회 테스트")
+    @DisplayName("List<Wish> findAllByMemberId(Long memberId) - 위시 리스트 조회 테스트")
     class FindAllByMemberIdentifyNumberTests {
 
         @Test
         @DisplayName("정상적인 memberId로 위시 리스트 조회")
         void 정상적인_memberId로_위시_리스트_조회() {
-            WishItem wishItem = new WishItem(
+            Wish wish = new Wish(
                     null,
                     existingMember,
                     existingProduct,
                     LocalDateTime.now()
             );
-            wishRepository.save(wishItem);
+            wishRepository.save(wish);
 
-            List<WishItem> wishItems = wishRepository.findAllByMemberId(existingMember.getId());
+            List<Wish> wishes = wishRepository.findAllByMemberId(existingMember.getId());
             assertAll(
-                () -> assertThat(wishItems).hasSize(1),
-                () -> assertThat(wishItems.get(0).getId()).isNotNull(),
-                () -> assertThat(wishItems.get(0).getMember().getId()).isEqualTo(existingMember.getId()),
-                () -> assertThat(wishItems.get(0).getProduct().getId()).isEqualTo(existingProduct.getId())
+                () -> assertThat(wishes).hasSize(1),
+                () -> assertThat(wishes.get(0).getId()).isNotNull(),
+                () -> assertThat(wishes.get(0).getMember().getId()).isEqualTo(existingMember.getId()),
+                () -> assertThat(wishes.get(0).getProduct().getId()).isEqualTo(existingProduct.getId())
             );
         }
 
         @Test
         @DisplayName("존재하지 않는 memberId로 위시 아이템 조회 시 빈 리스트 반환")
         void 존재하지_않는_memberId로_위시_아이템_조회_시_빈_리스트_반환() {
-            List<WishItem> wishItems = wishRepository.findAllByMemberId(999L);
-            assertThat(wishItems).hasSize(0);
+            List<Wish> wishes = wishRepository.findAllByMemberId(999L);
+            assertThat(wishes).hasSize(0);
         }
     }
 
@@ -144,34 +144,34 @@ class WishRepositoryTest {
         @Test
         @DisplayName("정상적인 memberId와 wishId로 위시 아이템 삭제 시 삭제")
         void 정상적인_memberId와_productId로_위시_아이템_삭제_시_삭제() {
-            WishItem wishItem = new WishItem(
+            Wish wish = new Wish(
                     null,
                     existingMember,
                     existingProduct,
                     LocalDateTime.now()
             );
-            wishItem = wishRepository.save(wishItem);
+            wish = wishRepository.save(wish);
 
-            assertThat(wishRepository.findById(wishItem.getId())).isPresent();
-            wishRepository.deleteByIdAndMemberId(wishItem.getId(), existingMember.getId());
-            assertThat(wishRepository.findById(wishItem.getId())).isEmpty();
+            assertThat(wishRepository.findById(wish.getId())).isPresent();
+            wishRepository.deleteByIdAndMemberId(wish.getId(), existingMember.getId());
+            assertThat(wishRepository.findById(wish.getId())).isEmpty();
         }
 
         @Test
         @DisplayName("존재하는 memberId에 대해 존재하지 않는 productId로 위시 아이템 삭제 시 미삭제")
         void 존재하는_memberId에_대해_존재하지_않는_productId로_위시_아이템_삭제_시_미삭제() {
-            // 본인 소유가 아닌 wishItem 삭제 시도
-            WishItem wishItem = new WishItem(
+            // 본인 소유가 아닌 wish 삭제 시도
+            Wish wish = new Wish(
                     null,
                     existingMember,
                     existingProduct,
                     LocalDateTime.now()
             );
-            wishItem = wishRepository.save(wishItem);
+            wish = wishRepository.save(wish);
 
-            assertThat(wishRepository.findById(wishItem.getId())).isPresent();
-            wishRepository.deleteByIdAndMemberId(wishItem.getId(), 999L);
-            assertThat(wishRepository.findById(wishItem.getId())).isPresent();
+            assertThat(wishRepository.findById(wish.getId())).isPresent();
+            wishRepository.deleteByIdAndMemberId(wish.getId(), 999L);
+            assertThat(wishRepository.findById(wish.getId())).isPresent();
         }
     }
 }

--- a/src/test/java/gift/repository/WishRepositoryTest.java
+++ b/src/test/java/gift/repository/WishRepositoryTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.Page;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -113,20 +114,20 @@ class WishRepositoryTest {
             );
             wishRepository.save(wish);
 
-            List<Wish> wishes = wishRepository.findAllByMemberId(existingMember.getId());
+            Page<Wish> wishes = wishRepository.findAllByMemberId(existingMember.getId(), null);
             assertAll(
-                () -> assertThat(wishes).hasSize(1),
-                () -> assertThat(wishes.get(0).getId()).isNotNull(),
-                () -> assertThat(wishes.get(0).getMember().getId()).isEqualTo(existingMember.getId()),
-                () -> assertThat(wishes.get(0).getProduct().getId()).isEqualTo(existingProduct.getId())
+                () -> assertThat(wishes.getContent()).hasSize(1),
+                () -> assertThat(wishes.getContent().get(0).getId()).isNotNull(),
+                () -> assertThat(wishes.getContent().get(0).getMember().getId()).isEqualTo(existingMember.getId()),
+                () -> assertThat(wishes.getContent().get(0).getProduct().getId()).isEqualTo(existingProduct.getId())
             );
         }
 
         @Test
         @DisplayName("존재하지 않는 memberId로 위시 아이템 조회 시 빈 리스트 반환")
         void 존재하지_않는_memberId로_위시_아이템_조회_시_빈_리스트_반환() {
-            List<Wish> wishes = wishRepository.findAllByMemberId(999L);
-            assertThat(wishes).hasSize(0);
+            Page<Wish> wishes = wishRepository.findAllByMemberId(999L, null);
+            assertThat(wishes.getContent()).hasSize(0);
         }
     }
 

--- a/src/test/java/gift/repository/WishRepositoryTest.java
+++ b/src/test/java/gift/repository/WishRepositoryTest.java
@@ -14,6 +14,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 @DataJpaTest
 class WishRepositoryTest {
@@ -68,7 +69,7 @@ class WishRepositoryTest {
             WishItem savedWishItem = wishRepository.save(wishItem);
             assertAll(
                 () -> assertThat(savedWishItem.getId()).isNotNull(),
-                () -> assertThat(savedWishItem.getMember().getIdentifyNumber()).isEqualTo(existingMember.getIdentifyNumber()),
+                () -> assertThat(savedWishItem.getMember().getId()).isEqualTo(existingMember.getId()),
                 () -> assertThat(savedWishItem.getProduct().getId()).isEqualTo(existingProduct.getId())
             );
         }
@@ -105,7 +106,7 @@ class WishRepositoryTest {
     }
 
     @Nested
-    @DisplayName("List<WishItem> findAllByMemberIdentifyNumber(Long memberId) - 위시 리스트 조회 테스트")
+    @DisplayName("List<WishItem> findAllByMemberId(Long memberId) - 위시 리스트 조회 테스트")
     class FindAllByMemberIdentifyNumberTests {
 
         @Test
@@ -119,11 +120,11 @@ class WishRepositoryTest {
             );
             wishRepository.save(wishItem);
 
-            List<WishItem> wishItems = wishRepository.findAllByMemberIdentifyNumber(existingMember.getIdentifyNumber());
+            List<WishItem> wishItems = wishRepository.findAllByMemberId(existingMember.getId());
             assertAll(
                 () -> assertThat(wishItems).hasSize(1),
                 () -> assertThat(wishItems.get(0).getId()).isNotNull(),
-                () -> assertThat(wishItems.get(0).getMember().getIdentifyNumber()).isEqualTo(existingMember.getIdentifyNumber()),
+                () -> assertThat(wishItems.get(0).getMember().getId()).isEqualTo(existingMember.getId()),
                 () -> assertThat(wishItems.get(0).getProduct().getId()).isEqualTo(existingProduct.getId())
             );
         }
@@ -131,18 +132,18 @@ class WishRepositoryTest {
         @Test
         @DisplayName("존재하지 않는 memberId로 위시 아이템 조회 시 빈 리스트 반환")
         void 존재하지_않는_memberId로_위시_아이템_조회_시_빈_리스트_반환() {
-            List<WishItem> wishItems = wishRepository.findAllByMemberIdentifyNumber(999L);
+            List<WishItem> wishItems = wishRepository.findAllByMemberId(999L);
             assertThat(wishItems).hasSize(0);
         }
     }
 
     @Nested
-    @DisplayName("Integer removeByMemberIdentifyNumberAndId(Long memberId, Long wishId) - 위시 아이템 삭제 테스트")
+    @DisplayName("Integer deleteByIdAndMemberId(Long memberId, Long wishId) - 위시 아이템 삭제 테스트")
     class RemoveByMemberIdentifyNumberAndProductIdTests {
 
         @Test
-        @DisplayName("정상적인 memberId와 wishId로 위시 아이템 삭제")
-        void 정상적인_memberId와_productId로_위시_아이템_삭제_시_1반환() {
+        @DisplayName("정상적인 memberId와 wishId로 위시 아이템 삭제 시 삭제")
+        void 정상적인_memberId와_productId로_위시_아이템_삭제_시_삭제() {
             WishItem wishItem = new WishItem(
                     null,
                     existingMember,
@@ -151,12 +152,14 @@ class WishRepositoryTest {
             );
             wishItem = wishRepository.save(wishItem);
 
-            assertThat(wishRepository.removeByMemberIdentifyNumberAndId(existingMember.getIdentifyNumber(), wishItem.getId())).isEqualTo(1);
+            assertThat(wishRepository.findById(wishItem.getId())).isPresent();
+            wishRepository.deleteByIdAndMemberId(wishItem.getId(), existingMember.getId());
+            assertThat(wishRepository.findById(wishItem.getId())).isEmpty();
         }
 
         @Test
-        @DisplayName("존재하는 memberId에 대해 존재하지 않는 productId로 위시 아이템 삭제 시 false 반환")
-        void 존재하는_memberId에_대해_존재하지_않는_productId로_위시_아이템_삭제_시_0반환() {
+        @DisplayName("존재하는 memberId에 대해 존재하지 않는 productId로 위시 아이템 삭제 시 미삭제")
+        void 존재하는_memberId에_대해_존재하지_않는_productId로_위시_아이템_삭제_시_미삭제() {
             // 본인 소유가 아닌 wishItem 삭제 시도
             WishItem wishItem = new WishItem(
                     null,
@@ -166,8 +169,9 @@ class WishRepositoryTest {
             );
             wishItem = wishRepository.save(wishItem);
 
-            assertThat(wishRepository.removeByMemberIdentifyNumberAndId(999L, wishItem.getId())).isEqualTo(0);
-
+            assertThat(wishRepository.findById(wishItem.getId())).isPresent();
+            wishRepository.deleteByIdAndMemberId(wishItem.getId(), 999L);
+            assertThat(wishRepository.findById(wishItem.getId())).isPresent();
         }
     }
 }

--- a/src/test/java/gift/repository/WishRepositoryTest.java
+++ b/src/test/java/gift/repository/WishRepositoryTest.java
@@ -61,10 +61,8 @@ class WishRepositoryTest {
         @DisplayName("정상적인 위시 아이템 데이터 삽입")
         void 정상적인_위시_아이템_삽입_시_정상반환() {
             Wish wish = new Wish(
-                    null,
                     existingMember,
-                    existingProduct,
-                    LocalDateTime.now()
+                    existingProduct
             );
             Wish savedWish = wishRepository.save(wish);
             assertAll(
@@ -77,15 +75,14 @@ class WishRepositoryTest {
         @Test
         @DisplayName("null 값이 포함된 위시 아이템 데이터 삽입 시 예외 발생")
         void 널_값이_포함된_위시_아이템_삽입_시_예외_발생() {
-            // id는 항상 null인 상태로 삽입되어야 함
 
-            Wish allNullWish = new Wish(null, null, null, null);
+            Wish allNullWish = new Wish(null, null);
             Assertions.assertThrows(DataIntegrityViolationException.class, () -> wishRepository.save(allNullWish));
 
-            Wish memberNullWish = new Wish(null, null, existingProduct, LocalDateTime.now());
+            Wish memberNullWish = new Wish(null, existingProduct);
             Assertions.assertThrows(DataIntegrityViolationException.class, () -> wishRepository.save(memberNullWish));
 
-            Wish productNullWish = new Wish(null, existingMember, null, LocalDateTime.now());
+            Wish productNullWish = new Wish(existingMember, null);
             Assertions.assertThrows(DataIntegrityViolationException.class, () -> wishRepository.save(productNullWish));
         }
 
@@ -96,10 +93,8 @@ class WishRepositoryTest {
             Member nonExistentMember = new Member(999L, null, null, null);
             Product nonExistentProduct = new Product(999L, null, null, null, null, null);
             Wish wish = new Wish(
-                  null,
                     nonExistentMember,
-                    nonExistentProduct,
-                    LocalDateTime.now()
+                    nonExistentProduct
             );
             Assertions.assertThrows(DataIntegrityViolationException.class, () -> wishRepository.save(wish));
         }
@@ -113,10 +108,8 @@ class WishRepositoryTest {
         @DisplayName("정상적인 memberId로 위시 리스트 조회")
         void 정상적인_memberId로_위시_리스트_조회() {
             Wish wish = new Wish(
-                    null,
                     existingMember,
-                    existingProduct,
-                    LocalDateTime.now()
+                    existingProduct
             );
             wishRepository.save(wish);
 
@@ -145,10 +138,8 @@ class WishRepositoryTest {
         @DisplayName("정상적인 memberId와 wishId로 위시 아이템 삭제 시 삭제")
         void 정상적인_memberId와_productId로_위시_아이템_삭제_시_삭제() {
             Wish wish = new Wish(
-                    null,
                     existingMember,
-                    existingProduct,
-                    LocalDateTime.now()
+                    existingProduct
             );
             wish = wishRepository.save(wish);
 
@@ -162,10 +153,8 @@ class WishRepositoryTest {
         void 존재하는_memberId에_대해_존재하지_않는_productId로_위시_아이템_삭제_시_미삭제() {
             // 본인 소유가 아닌 wish 삭제 시도
             Wish wish = new Wish(
-                    null,
                     existingMember,
-                    existingProduct,
-                    LocalDateTime.now()
+                    existingProduct
             );
             wish = wishRepository.save(wish);
 

--- a/src/test/java/gift/service/MemberServiceTest.java
+++ b/src/test/java/gift/service/MemberServiceTest.java
@@ -17,7 +17,6 @@ import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.web.server.ResponseStatusException;
 
-import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -65,8 +64,8 @@ class MemberServiceTest {
                 assertAll(
                         () -> assertThat(resolve.getEmail()).isEqualTo(email),
                         () -> assertThat(resolve.getPassword()).isEqualTo(hashedPassword),
-                        () -> assertThat(resolve.getIdentifyNumber()).isEqualTo(1L),
-                        () -> assertThat(resolve.getAuthority()).isEqualTo(Role.ROLE_USER)
+                        () -> assertThat(resolve.getId()).isEqualTo(1L),
+                        () -> assertThat(resolve.getRole()).isEqualTo(Role.ROLE_USER)
                 );
             }
         }
@@ -161,10 +160,10 @@ class MemberServiceTest {
             UpdateMemberResult result = memberService.updateSelectivelyMember(id, newEmail, false, newRole);
 
             assertAll(
-                    () -> assertThat(result.member().getIdentifyNumber()).isEqualTo(id),
+                    () -> assertThat(result.member().getId()).isEqualTo(id),
                     () -> assertThat(result.member().getEmail()).isEqualTo(newEmail),
                     () -> assertThat(result.member().getPassword()).isEqualTo(hashedPassword),
-                    () -> assertThat(result.member().getAuthority()).isEqualTo(newRole),
+                    () -> assertThat(result.member().getRole()).isEqualTo(newRole),
                     () -> assertThat(result.temporalPassword()).isEmpty()
             );
         }
@@ -190,10 +189,10 @@ class MemberServiceTest {
                 UpdateMemberResult result = memberService.updateSelectivelyMember(id, newEmail, true, newRole);
 
                 assertAll(
-                        () -> assertThat(result.member().getIdentifyNumber()).isEqualTo(id),
+                        () -> assertThat(result.member().getId()).isEqualTo(id),
                         () -> assertThat(result.member().getEmail()).isEqualTo(newEmail),
                         () -> assertThat(result.member().getPassword()).isEqualTo(newPassword),
-                        () -> assertThat(result.member().getAuthority()).isEqualTo(newRole),
+                        () -> assertThat(result.member().getRole()).isEqualTo(newRole),
                         () -> assertThat(result.temporalPassword()).isNotEmpty()
                 );
             }

--- a/src/test/java/gift/service/MemberServiceTest.java
+++ b/src/test/java/gift/service/MemberServiceTest.java
@@ -1,6 +1,6 @@
 package gift.service;
 
-import gift.dto.UpdateMemberResult;
+import gift.dto.UpdateMemberResponse;
 import gift.entity.Member;
 import gift.entity.Role;
 import gift.exception.InvalidCredentialsException;
@@ -157,14 +157,14 @@ class MemberServiceTest {
             when(memberRepository.findById(id)).thenReturn(Optional.of(existingMember));
             when(memberRepository.findByEmail(newEmail)).thenReturn(Optional.empty());
 
-            UpdateMemberResult result = memberService.updateSelectivelyMember(id, newEmail, false, newRole);
+            UpdateMemberResponse result = memberService.updateSelectivelyMember(id, newEmail, false, newRole);
 
             assertAll(
                     () -> assertThat(result.member().getId()).isEqualTo(id),
                     () -> assertThat(result.member().getEmail()).isEqualTo(newEmail),
                     () -> assertThat(result.member().getPassword()).isEqualTo(hashedPassword),
                     () -> assertThat(result.member().getRole()).isEqualTo(newRole),
-                    () -> assertThat(result.temporalPassword()).isEmpty()
+                    () -> assertThat(result.temporalPassword()).isNull()
             );
         }
 
@@ -186,14 +186,14 @@ class MemberServiceTest {
             try (MockedStatic<BCryptEncryptor> encryptor = mockStatic(BCryptEncryptor.class)) {
                 encryptor.when(() -> BCryptEncryptor.encrypt(any())).thenReturn(newPassword);
 
-                UpdateMemberResult result = memberService.updateSelectivelyMember(id, newEmail, true, newRole);
+                UpdateMemberResponse result = memberService.updateSelectivelyMember(id, newEmail, true, newRole);
 
                 assertAll(
                         () -> assertThat(result.member().getId()).isEqualTo(id),
                         () -> assertThat(result.member().getEmail()).isEqualTo(newEmail),
                         () -> assertThat(result.member().getPassword()).isEqualTo(newPassword),
                         () -> assertThat(result.member().getRole()).isEqualTo(newRole),
-                        () -> assertThat(result.temporalPassword()).isNotEmpty()
+                        () -> assertThat(result.temporalPassword()).isNotNull()
                 );
             }
         }

--- a/src/test/java/gift/service/MemberServiceTest.java
+++ b/src/test/java/gift/service/MemberServiceTest.java
@@ -3,6 +3,7 @@ package gift.service;
 import gift.dto.UpdateMemberResponse;
 import gift.entity.Member;
 import gift.entity.Role;
+import gift.exception.ConflictException;
 import gift.exception.InvalidCredentialsException;
 import gift.repository.MemberRepository;
 import gift.token.JwtTokenProvider;
@@ -78,7 +79,7 @@ class MemberServiceTest {
 
             when(memberRepository.findByEmail(email)).thenReturn(Optional.of(new Member(100L, email, "hashedPassword", null)));
 
-            assertThrows(ResponseStatusException.class, () -> memberService.createMember(email, rawPassword));
+            assertThrows(ConflictException.class, () -> memberService.createMember(email, rawPassword));
         }
     }
 

--- a/src/test/java/gift/service/ProductServiceTest.java
+++ b/src/test/java/gift/service/ProductServiceTest.java
@@ -1,6 +1,7 @@
 package gift.service;
 
 import gift.entity.Product;
+import gift.exception.NotFoundException;
 import gift.repository.ProductRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -60,7 +61,7 @@ class ProductServiceTest {
             Long productId = 999L;
             when(productRepository.findByIdAndDeletedIsFalse(productId)).thenReturn(Optional.empty());
 
-            assertThrows(ResponseStatusException.class, () -> productService.getProductById(productId));
+            assertThrows(NotFoundException.class, () -> productService.getProductById(productId));
         }
     }
 
@@ -84,7 +85,7 @@ class ProductServiceTest {
             Long productId = 999L;
             when(productRepository.findById(productId)).thenReturn(Optional.empty());
 
-            assertThrows(ResponseStatusException.class, () -> productService.getProductWhetherDeletedById(productId));
+            assertThrows(NotFoundException.class, () -> productService.getProductWhetherDeletedById(productId));
         }
     }
 

--- a/src/test/java/gift/service/ProductServiceTest.java
+++ b/src/test/java/gift/service/ProductServiceTest.java
@@ -34,7 +34,7 @@ class ProductServiceTest {
         String name = "Test Product";
         Integer price = 10000;
         String imageUrl = "http://example.com/image.jpg";
-        Product expectedProduct = new Product(1L, name, price, imageUrl, false);
+        Product expectedProduct = new Product(1L, name, price, imageUrl, false, false);
         when(productRepository.save(any())).thenReturn(expectedProduct);
 
         assertThat(productService.createProduct(name, price, imageUrl)).isEqualTo(expectedProduct);
@@ -48,7 +48,7 @@ class ProductServiceTest {
         @DisplayName("존재하는 상품 ID로 조회 시 상품 반환")
         void 존재하는상품ID로조회시_상품반환() {
             Long productId = 1L;
-            Product expectedProduct = new Product(productId, "Test Product", 10000, "http://example.com/image.jpg", false);
+            Product expectedProduct = new Product(productId, "Test Product", 10000, "http://example.com/image.jpg", false, false);
             when(productRepository.findByIdAndDeletedIsFalse(productId)).thenReturn(Optional.of(expectedProduct));
 
             assertThat(productService.getProductById(productId)).isEqualTo(expectedProduct);
@@ -72,7 +72,7 @@ class ProductServiceTest {
         @DisplayName("존재하는 상품 ID로 조회 시 상품 반환")
         void 존재하는상품ID로조회시_상품반환() {
             Long productId = 1L;
-            Product expectedProduct = new Product(productId, "Test Product", 10000, "http://example.com/image.jpg", false);
+            Product expectedProduct = new Product(productId, "Test Product", 10000, "http://example.com/image.jpg", false, false);
             when(productRepository.findById(productId)).thenReturn(Optional.of(expectedProduct));
 
             assertThat(productService.getProductWhetherDeletedById(productId)).isEqualTo(expectedProduct);


### PR DESCRIPTION
안녕하세요. Step2 구현 PR드립니다.

총 PR요청 올려드린 내용은 크게 3가지 내용입니다.
1. Step1에서 코드리뷰받은 내용에 대한 코드수정
2. Step2 (페이지네이션) 구현
3. Step2 구현 후 코드 리펙토링 등

이중 1번 내용에 대해서는 이전 PR간 코멘트 남겨주신 사항을 반영한 것입니다.
중점적으로 PR요청드리는 파트는 특히 2번내용입니다.


아래에, 상세 구현내용을 정리드립니다.

## Step2 PR
### before step2 implementation
#### [refactor]
- Entity 클래스
  - [x] 엔티티(`Member`, `Product`, `Wish`)의 id setter 제거
  - [x] Member 테이블의 컬럼명 변경
    - `@Id` 어노테이션을 사용하는 `IdentifyNumber(identify_number)` 컬럼의 이름을 `id`로 변경
    - `Role` enum 타입의 `authority` 컬럼의 이름을 `role`로 변경
  - [x] Wish 테이블(기존 WishItem 클래스) 리펙터링
    - 클래스명을 `Wish`로 변경 : 테이블명인 `wish`와 클래스명인 `WishItem`의 불일치 해결 목적
    - 접근제어자 추가 : `default`(미기재)에서 `private`로 변경하여 외부에서 접근 불가하도록 조치
  - [x] 엔티티의 생성자 정리 (생성자 통폐합 및 불필요 생성자 제거)
- Dto 클래스
  - [x] `UpdateMemberResult` Dto 리팩터링
    - `UpdateMemberResponse`로 이름 변경 : Dto의 이름은 Request와 Response로 통일
    - `Optional` 타입의 `temporalPassword` 필드를 `String` 타입으로 변경 : Optional 타입은 필드 / 매개변수 / 컬렉션 원소타입으로 사용하지 않도록 조치
- Repository 클래스
  - [x] ProductRepository 인터페이스 리펙터링
    - `findAllByDeletedIsFalseAndValidated` 메소드의 매개변수명을 `visibility`에서 컬럼명인 `validated`로 변경
  - [x] Repository 레이어의 삭제 메소드 리펙터링
    - `removeOO` 메소드를 `deleteOO`로 변경
    - 반환타입을 일괄 void형으로 변경
- Service 클래스
  - [x] Service 레이어의 `@Transactional` 어노테이션의 사용위치 변경
    - 기존 클래스 단으로 적용하던 `@Transactional` 어노테이션을 메소드별로 변경
  - [x] Service 레이어의 `throwNotFoundException` 메소드 삭제
    - MemberService, ProductService 클래스에 해당
  - [x] Service 레이어의 `deleteOO` 메소드 호출부 변경
    - hard delete 사용되는 MemberService, WishService 클래스에 해당
    - `deleteOO` 메소드가 void 타입으로 변경됨에 따라, 해당 메소드 호출부 이전에 `findOO` 메소드로 조회 후, 해당 객체가 존재하는지 여부를 확인하는 로직 추가
  - [x] MemberService 클래스의 `generateRandomPassword` 메소드 위치 변경
    - 별도 utility 클래스로 분리하여 `PasswordUtils` 클래스에 위치
#### [fix]
- [x] Wish 테이블 수정
  - Product와의 연관관계 매핑 변경 : `@OneToOne`에서 `@ManyToOne` 어노테이션으로 변경하여, 여러명(여러 Wish)이 하나의 Product를 참조할 수 있도록 조치
### Step2 implementation
- [x] 페이징 구현
  - API, Admin Page(Thymeleaf)에서 페이징 기능 구현
  - Admin Page 페이징 UI 구현 (assisted by AI, implemented by bootstrap)
### after step2 implementation
#### [feat]
- [x] Admin Page 전역 UI 개선 (assisted by AI, implemented by bootstrap)
#### [fix]
- [x] Admin Page 예외페이지 정상작동 구현
  - Custom Exception 및 Custom Exception Handler 구현
#### [refactor]
- [x] Page 반환방법을 Dto 사용하는 것으로 변경
  - `Page` 객체를 직접 반환하는 대신, `PageResponse` Dto로 변환하여 반환


감사합니다.