### PR TITLE
전남대 최지민 Step2 페이지네이션 

### DIFF
--- a/src/main/java/gift/controller/WishRestController.java
+++ b/src/main/java/gift/controller/WishRestController.java
@@ -5,6 +5,7 @@ import gift.dto.*;
 import gift.login.Login;
 import gift.login.LoginMember;
 import gift.service.WishService;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -24,9 +25,9 @@ public class WishRestController {
     }
 
     @GetMapping("/products")
-    public HttpEntity<List<Product>> getProducts() {
-        List<Product> productList = service.productList();
-        return new ResponseEntity<>(productList, HttpStatus.OK);
+    public HttpEntity<PageResponse<Product>> getProducts(Pageable pageable){
+        PageResponse<Product> pagedProductList = service.productList(pageable);
+        return new ResponseEntity<>(pagedProductList, HttpStatus.OK);
     }
 
     @PostMapping()
@@ -37,9 +38,10 @@ public class WishRestController {
     }
 
     @GetMapping
-    public HttpEntity<List<WishResponse>> getWishList(@Login LoginMember loginMember) {
-        List<WishResponse> wishList = service.getMemberWishList(loginMember.id());
-        return new ResponseEntity<>(wishList, HttpStatus.OK);
+    public HttpEntity<PageResponse<WishResponse>> getWishList(@Login LoginMember loginMember, Pageable pageable) {
+        PageResponse<WishResponse> pagedMemberWishList = service.getMemberWishList(loginMember.id(),
+                pageable);
+        return new ResponseEntity<>(pagedMemberWishList, HttpStatus.OK);
     }
 
     @DeleteMapping("/{wishId}")

--- a/src/main/java/gift/domain/Wish.java
+++ b/src/main/java/gift/domain/Wish.java
@@ -56,4 +56,8 @@ public class Wish {
     public void update(int quantity) {
         this.quantity = quantity;
     }
+
+    public void addQuantity(int quantity) {
+        this.quantity += quantity;
+    }
 }

--- a/src/main/java/gift/dto/PageResponse.java
+++ b/src/main/java/gift/dto/PageResponse.java
@@ -1,0 +1,24 @@
+package gift.dto;
+
+import java.util.List;
+import org.springframework.data.domain.Page;
+
+public record PageResponse<T> (
+        List<T> pageList,
+        int page,
+        int size,
+        long totalElements,
+        int totalPages,
+        boolean hasNext
+){
+    public static <T>PageResponse<T> from(Page<T> product) {
+        return new PageResponse<>(
+                product.getContent(),
+                product.getNumber(),
+                product.getSize(),
+                product.getTotalElements(),
+                product.getTotalPages(),
+                product.hasNext()
+        );
+    }
+}

--- a/src/main/java/gift/repository/WishJpaRepository.java
+++ b/src/main/java/gift/repository/WishJpaRepository.java
@@ -1,10 +1,16 @@
 package gift.repository;
 
 import gift.domain.Wish;
+import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface WishJpaRepository extends JpaRepository<Wish, Long> {
     Page<Wish> findByMemberId(Long memberId, Pageable pageable);
+
+    @Query("select w from Wish w where w.member.id = :memberId and w.product.id = :productId")
+    Optional<Wish> findByMemberIdAndProductId(@Param("memberId") Long memberId, @Param("productId") Long productId);
 }

--- a/src/main/java/gift/repository/WishJpaRepository.java
+++ b/src/main/java/gift/repository/WishJpaRepository.java
@@ -1,9 +1,10 @@
 package gift.repository;
 
 import gift.domain.Wish;
-import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface WishJpaRepository extends JpaRepository<Wish, Long> {
-    List<Wish> findByMemberId(Long memberId);
+    Page<Wish> findByMemberId(Long memberId, Pageable pageable);
 }

--- a/src/main/java/gift/service/WishService.java
+++ b/src/main/java/gift/service/WishService.java
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Service;
 
 import java.util.NoSuchElementException;
 import java.util.Optional;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class WishService {
@@ -33,9 +34,18 @@ public class WishService {
         return PageResponse.from(productRepository.findAll(pageable));
     }
 
+    @Transactional
     public CreateWishResponse addWishProduct(CreateWishRequest request, Long loginMemberId) {
         Member member = memberRepository.findById(loginMemberId).orElseThrow(() -> new NoSuchElementException("존재하지 않는 멤버입니다."));
         Product product = productRepository.findById(request.productId()).orElseThrow(() -> new NoSuchElementException("존재하지 않는 상품입니다."));
+
+        if (isPresent(member, product)) {
+            Wish presentWish = wishJpaRepository.findByMemberIdAndProductId(member.getId(), product.getId()).get();
+            presentWish.addQuantity(request.quantity());
+            return new CreateWishResponse(presentWish.getId(), presentWish.getMember().getId(),
+                    presentWish.getProduct().getId(),
+                    presentWish.getQuantity());
+        }
         Wish wish = wishJpaRepository.save(new Wish(null, member, product, request.quantity()));
         return new CreateWishResponse(wish.getId(), wish.getMember().getId(), wish.getProduct().getId(), wish.getQuantity());
     }
@@ -50,17 +60,24 @@ public class WishService {
                 )));
     }
 
+    @Transactional
     public void delete(Long wishId, Long memberId) {
         Wish wishProduct = findByIdOrThrow(wishId);
         checkAuthorization(wishProduct, memberId, "삭제 권한 없음");
         wishJpaRepository.deleteById(wishId);
     }
 
+    @Transactional
     public UpdateWishResponse updateQuantity(UpdateWishRequest request, Long wishId, Long memberId) {
         Wish wishProduct = findByIdOrThrow(wishId);
         checkAuthorization(wishProduct, memberId, "수정 권한 없음");
         wishProduct.update(request.quantity());
         return new UpdateWishResponse(wishProduct.getId(), wishProduct.getId(), request.quantity());
+    }
+
+    private boolean isPresent(Member member, Product product) {
+        return wishJpaRepository.findByMemberIdAndProductId(member.getId(), product.getId())
+                .isPresent();
     }
 
     private static void checkAuthorization(Wish wishProduct, Long memberId, String exMessage) {

--- a/src/main/java/gift/service/WishService.java
+++ b/src/main/java/gift/service/WishService.java
@@ -8,9 +8,9 @@ import gift.dto.*;
 import gift.repository.MemberJpaRepository;
 import gift.repository.ProductJpaRepository;
 import gift.repository.WishJpaRepository;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
-import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 
@@ -29,8 +29,8 @@ public class WishService {
     }
 
 
-    public List<Product> productList() {
-        return productRepository.findAll();
+    public PageResponse<Product> productList(Pageable pageable) {
+        return PageResponse.from(productRepository.findAll(pageable));
     }
 
     public CreateWishResponse addWishProduct(CreateWishRequest request, Long loginMemberId) {
@@ -40,16 +40,16 @@ public class WishService {
         return new CreateWishResponse(wish.getId(), wish.getMember().getId(), wish.getProduct().getId(), wish.getQuantity());
     }
 
-    public List<WishResponse> getMemberWishList(Long memberId) {
-        return wishJpaRepository.findByMemberId(memberId).stream()
+    public PageResponse<WishResponse> getMemberWishList(Long memberId, Pageable pageable) {
+        return PageResponse.from(wishJpaRepository.findByMemberId(memberId, pageable)
                 .map(wish -> new WishResponse(
                         wish.getId(),
                         wish.getProduct().getName(),
                         wish.getProduct().getPrice(),
                         wish.getQuantity()
-                ))
-                .toList();
+                )));
     }
+
     public void delete(Long wishId, Long memberId) {
         Wish wishProduct = findByIdOrThrow(wishId);
         checkAuthorization(wishProduct, memberId, "삭제 권한 없음");

--- a/src/test/java/gift/repository/MemberJpaRepositoryTest.java
+++ b/src/test/java/gift/repository/MemberJpaRepositoryTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.*;
 
 import gift.domain.Member;
 import gift.util.ShaUtil;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
@@ -17,6 +18,7 @@ class MemberJpaRepositoryTest {
 
 
     @Test
+    @DisplayName("멤버 저장")
     void save() {
         String password = "123";
         String salt = ShaUtil.getSalt();
@@ -27,59 +29,77 @@ class MemberJpaRepositoryTest {
     }
 
     @Test
+    @DisplayName("ID로 멤버 조회 ")
     void findById() {
+        //when
         String password = "123";
         String salt = ShaUtil.getSalt();
         String encryptPassword = ShaUtil.encrypt(password, salt);
+        //given
         Member saveMember = repository.save(
                 new Member(null, "ex@email.com", encryptPassword, salt));
+        //then
         assertThat(repository.findById(saveMember.getId()).get()).isEqualTo((saveMember));
     }
 
     @Test
+    @DisplayName("이메일로 멤버 조회")
     void findByEmail() {
+        //when
         String password = "123";
         String salt = ShaUtil.getSalt();
         String encryptPassword = ShaUtil.encrypt(password, salt);
+        //given
         Member saveMember = repository.save(
                 new Member(null, "ex@email.com", encryptPassword, salt));
+        //then
         assertThat(repository.findByEmail(saveMember.getEmail()).get()).isEqualTo(saveMember);
     }
 
     @Test
+    @DisplayName("멤버 전체 조회")
     void findAll() {
+        //when
         String password = "123";
         String salt = ShaUtil.getSalt();
         String encryptPassword = ShaUtil.encrypt(password, salt);
+        //given
         Member saveMember1 = repository.save(
                 new Member(null, "ex1@email.com", encryptPassword, salt));
         Member saveMember2 = repository.save(
                 new Member(null, "ex2@email.com", encryptPassword, salt));
+        //then
         assertThat(repository.findAll().size()).isEqualTo(2);
     }
 
     @Test
+    @DisplayName("멤버 수정")
     void update() {
+        //when
         String password = "123";
         String salt = ShaUtil.getSalt();
         String encryptPassword = ShaUtil.encrypt(password, salt);
         Member saveMember = repository.save(
                 new Member(null, "ex@email.com", encryptPassword, salt));
-
+        //given
         saveMember.update("update@email.com", encryptPassword, salt);
-
+        //then
         assertThat(repository.findById(saveMember.getId()).get().getEmail()).isEqualTo(
                 "update@email.com");
     }
 
     @Test
+    @DisplayName("멤버 삭제")
     void delete() {
+        //when
         String password = "123";
         String salt = ShaUtil.getSalt();
         String encryptPassword = ShaUtil.encrypt(password, salt);
         Member saveMember1 = repository.save(
                 new Member(null, "ex1@email.com", encryptPassword, salt));
+        //given
         repository.deleteById(saveMember1.getId());
+        //then
         assertThat(repository.findAll().size()).isEqualTo(0);
 
     }

--- a/src/test/java/gift/repository/ProductJpaRepositoryTest.java
+++ b/src/test/java/gift/repository/ProductJpaRepositoryTest.java
@@ -3,9 +3,12 @@ package gift.repository;
 import static org.assertj.core.api.Assertions.*;
 
 import gift.domain.Product;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 
 @DataJpaTest
 class ProductJpaRepositoryTest {
@@ -14,45 +17,62 @@ class ProductJpaRepositoryTest {
     private ProductJpaRepository repository;
 
     @Test
+    @DisplayName("상품 저장")
     void save() {
-        Product savedProduct = repository.save(
-                new Product(null, "product1", 1000, "url.com"));
+        //when
+        Product product = new Product(null, "product1", 1000, "url.com");
+        //given
+        Product savedProduct = repository.save(product);
+        //then
         assertThat(savedProduct.getId()).isNotNull();
     }
 
     @Test
+    @DisplayName("ID로 상품 조회")
     void findById() {
-        Product savedProduct = repository.save(
-                new Product(null, "product1", 1000, "url.com"));
+        //when
+        Product product = new Product(null, "product1", 1000, "url.com");
+        //given
+        Product savedProduct = repository.save(product);
+        //then
         assertThat(repository.findById(savedProduct.getId()).get()).isEqualTo(savedProduct);
     }
 
     @Test
+    @DisplayName("상품 페이지네이션 조회")
     void findAll() {
-        repository.save(
-                new Product(null, "product1", 1000, "url.com"));
-        repository.save(
-                new Product(null, "product2", 1000, "url.com"));
-        assertThat(repository.findAll().size()).isEqualTo(2);
+        //when
+        Product product1 = new Product(null, "product1", 1000, "url.com");
+        Product product2 = new Product(null, "product2", 1000, "url.com");
+        //given
+        repository.save(product1);
+        repository.save(product2);
+        Pageable pageable = PageRequest.of(0, 2);
+        //then
+        assertThat(repository.findAll(pageable).getContent().size()).isEqualTo(2);
     }
 
     @Test
+    @DisplayName("상품 수정")
     void update() {
-        Product savedProduct = repository.save(
-                new Product(null, "product1", 1000, "url.com"));
-
+        //when
+        Product product = new Product(null, "product1", 1000, "url.com");
+        Product savedProduct = repository.save(product);
+        //given
         savedProduct.update("updateName", 1000, "update.com");
-
+        //then
         assertThat(savedProduct.getName()).isEqualTo("updateName");
     }
 
     @Test
+    @DisplayName("상품 삭제")
     void delete() {
-        Product savedProduct = repository.save(
-                new Product(null, "product1", 1000, "url.com"));
-
+        //when
+        Product product = new Product(null, "product1", 1000, "url.com");
+        Product savedProduct = repository.save(product);
+        //given
         repository.deleteById(savedProduct.getId());
-
+        //then
         assertThat(repository.findAll()).size().isEqualTo(0);
     }
 }

--- a/src/test/java/gift/repository/WishJpaRepositoryTest.java
+++ b/src/test/java/gift/repository/WishJpaRepositoryTest.java
@@ -7,10 +7,13 @@ import gift.domain.Member;
 import gift.domain.Product;
 import gift.domain.Wish;
 import gift.util.ShaUtil;
-import java.util.List;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 
 @DataJpaTest
 class WishJpaRepositoryTest {
@@ -23,7 +26,9 @@ class WishJpaRepositoryTest {
     private ProductJpaRepository productRepository;
 
     @Test
+    @DisplayName("위시에 상품 저장")
     void save() {
+        //when
         String password = "123";
         String salt = ShaUtil.getSalt();
         String encryptPassword = ShaUtil.encrypt(password, salt);
@@ -33,12 +38,17 @@ class WishJpaRepositoryTest {
         Product savedProduct = productRepository.save(
                 new Product(null, "product1", 1000, "url.com"));
 
+        //given
         Wish savedWish = wishRepository.save(new Wish(null, member, savedProduct, 1));
+
+        //then
         assertThat(savedWish.getId()).isNotNull();
     }
 
     @Test
+    @DisplayName("멤버별로 상품 조회")
     void getWishListByMember() {
+        //when
         String password = "123";
         String salt = ShaUtil.getSalt();
         String encryptPassword = ShaUtil.encrypt(password, salt);
@@ -51,15 +61,50 @@ class WishJpaRepositoryTest {
         Product product2 = productRepository.save(
                 new Product(null, "product2", 1000, "url.com"));
 
+        //given
         wishRepository.save(new Wish(null, member, product1, 1));
         wishRepository.save(new Wish(null, member, product2, 1));
+        Pageable pageable = PageRequest.of(0, 10);
+        Page<Wish> wishes = wishRepository.findByMemberId(member.getId(), pageable);
 
-        List<Wish> members = wishRepository.findByMemberId(member.getId());
-        assertThat(members.size()).isEqualTo(2);
+        //then
+        assertThat(wishes.getContent().size()).isEqualTo(2);
     }
 
     @Test
+    @DisplayName("페이지네이션 테스트")
+    void 멤버별_상품조회_페이지네이션() {
+        //when
+        String password = "123";
+        String salt = ShaUtil.getSalt();
+        String encryptPassword = ShaUtil.encrypt(password, salt);
+        Member member = memberRepository.save(
+                new Member(null, "ex@email.com", encryptPassword, salt));
+
+        Product product1 = productRepository.save(
+                new Product(null, "product1", 1000, "url.com"));
+
+        Product product2 = productRepository.save(
+                new Product(null, "product2", 1000, "url.com"));
+
+        Product product3 = productRepository.save(
+                new Product(null, "product3", 1000, "url.com"));
+
+        //given
+        wishRepository.save(new Wish(null, member, product1, 1));
+        wishRepository.save(new Wish(null, member, product2, 1));
+        wishRepository.save(new Wish(null, member, product3, 1));
+        Pageable pageable = PageRequest.of(1, 2);
+        Page<Wish> wishes = wishRepository.findByMemberId(member.getId(), pageable);
+
+        //then
+        assertThat(wishes.getContent().size()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("수량 변경")
     void updateQuantity() {
+        //when
         String password = "123";
         String salt = ShaUtil.getSalt();
         String encryptPassword = ShaUtil.encrypt(password, salt);
@@ -70,12 +115,18 @@ class WishJpaRepositoryTest {
                 new Product(null, "product1", 1000, "url.com"));
 
         Wish savedWish = wishRepository.save(new Wish(null, member, savedProduct, 1));
+
+        //given
         savedWish.update(3);
+
+        //then
         assertThat(savedWish.getQuantity()).isEqualTo(3);
     }
 
     @Test
+    @DisplayName("위시 상품 삭제")
     void delete() {
+        //when
         String password = "123";
         String salt = ShaUtil.getSalt();
         String encryptPassword = ShaUtil.encrypt(password, salt);
@@ -90,9 +141,14 @@ class WishJpaRepositoryTest {
 
         Wish wish1 = new Wish(null, member, product1, 1);
         Wish wish2 = new Wish(null, member, product2, 1);
+
+        //given
         wishRepository.save(wish1);
         wishRepository.save(wish2);
         wishRepository.deleteById(wish1.getId());
-        assertThat(wishRepository.findByMemberId(member.getId()).size()).isEqualTo(1);
+        Pageable pagable = PageRequest.of(0, 10);
+
+        //then
+        assertThat(wishRepository.findByMemberId(member.getId(), pagable).getContent().size()).isEqualTo(1);
     }
 }

--- a/src/test/java/gift/repository/WishJpaRepositoryTest.java
+++ b/src/test/java/gift/repository/WishJpaRepositoryTest.java
@@ -27,7 +27,7 @@ class WishJpaRepositoryTest {
 
     @Test
     @DisplayName("위시에 상품 저장")
-    void save() {
+    void 위시_상품저장() {
         //when
         String password = "123";
         String salt = ShaUtil.getSalt();


### PR DESCRIPTION
### 구현 내용 
먼저 이번 단계의 메인 요구사항인 페이지네이션을 구현했습니다. 
JPA로 페이지네이션을 사용하려면 일단 클라이언트 쪽에서 페이지네이션과 관련된 정보와 함께 요청을 해야합니다. 
이 정보로 페이지네이션을 사용하는데 2가지 방법이 있는 것 같습니다. 

1. 해당 내용을 `@RequestParam`으로 파라미터를 매핑받아 서비스 계층으로 넘겨주시고 이를 `PageRequest.of`를 통해 Pagable 객체로 변환해 레포지토리에 넘겨주는 것입니다. 
2. 컨트롤러에서 바로 Pagable 객체로 받아 서비스, 레포지토리로 넘겨주는 것입니다. Pagable 객체는 페이지네이션 관련된 요청 정보를 알아서 매핑해 전달해줍니다. 
 
저는 Pagable을 사용했는데 작성할 코드양도 적고 간편하기 때문이었습니다. 그런데 `@RequestParam`을 사용하면 `require=false` 설정을 통해 페이지네이션 파라미터를 필수로 받지 않을 수 있다는 장점이 있는 것 같습니다. Pagable은 파라미터가 오지 않으면 default 값을 설정할 수 도있지만 기본적으로는 page=0, size=20이 기본 값입니다. 

그런데 레포지토리에서 Page<T> 으로 반환 받은 객체를 그대로 컨트롤러에 반환하면 클라이언트가 필요 없는 페이지네이션까지 전송하게 된다고 생각해 PageResponse DTO를 하나 만들어서 컨트롤러로 반환하게 했습니다.  

이렇게 페이지네이션을 구현했고 테스트 코드를 통해 정상적으로 작동한다는 것을 확인했습니다. 

그리고 Wish에 상품을 추가할 때 상품이 이미 존재하는데도 상품을 추가시 Wish가 하나 더 추가되는 것보다 기존 상품의 수량을 증가하는게 더 적절하다고 생각해 그 부분을 변경해보았습니다. 

### 배운점
API는 클라이언트를 배려해서 작성해야 한다고 배웠습니다. 페이지네이션을 사용하더라도 클라이언트가 어떤 정보가 필요하고 필요하지 않는지를 파악하는 것이 중요하겠다는 것을 느꼈습니다. 

그리고 WishRestController의 addWishProduct의 메서드가 상품이 존재하면 해당 상품의 수량을 증가하도록 메서드의 기능을 수정한 후 PostMan을 통해 잘 작동하는지 테스트 해보았습니다. 
그런데 이상하게도 요청은 정상적으로 가는 것 같은데 다시 상품을 조회해보면 상품의 수량이 변화하지 않았습니다. 
처음에는 제가 작성한 코드에 잘못된 부분이 있다고 생각했는데 알고 보니 `@Transactional` 어노테이션이 빠져 있어서 생긴 문제였습니다. 
제 요청에 의해서 자바 객체의 필드 값 자체는 수정되었지만 이 값이 flush 되지 않아 DB에 적용이 되지 않았던 것이었습니다. 
저는 당연히 더티 체킹에 의해 알아서 update 쿼리가 나갈 것이라고 에상했지만 update 쿼리가 나가고 있지 않았습니다. 
알고보니 더티체킹은 트랜젝션 커밋 시점에 스냅샷을 비교하고 이때 Update 쿼리를 생성한 후 flush 되는 동작 방식을 가지고 있었습니다. 
지금까지는 Test 코드의 `@DataJpaTest` 어노테이션에 트랜젝션 어노테이션이 포함되어 있어서 이를 체감하지 못하고 있었습니다. 
이 과정에서 `@Transactional`의 중요성을 알게 되었고 flush가 트랜젝션 커밋시점,  JPQL이 동작할 때 자동 호출된다는 것도 배우게 되었습니다.

