### PR TITLE
전남대 BE_이승원 2단계 - 페이지네이션

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # spring-gift-enhancement
 
+# 2단계 수행
+- product와 wishlist 전체 조회 시 페이지네이션 적용하기
+- 이전단계 피드백 반영
+
 # 1단계 수행
 - 엔티티와 레포지터리를 JPA로 리펙터링
 - DATAJPATEXT하기

--- a/src/main/java/gift/admin/controller/AdminProductController.java
+++ b/src/main/java/gift/admin/controller/AdminProductController.java
@@ -25,7 +25,7 @@ public class AdminProductController {
 
     @GetMapping
     public String findAllProduct(Model model) {
-        List<ProductResponseDto> products = productService.findAllProduct();
+        List<ProductResponseDto> products = productService.findAllProducts();
         model.addAttribute("products", products);
         return "admin/list";
     }

--- a/src/main/java/gift/member/controller/MemberController.java
+++ b/src/main/java/gift/member/controller/MemberController.java
@@ -1,9 +1,11 @@
 package gift.member.controller;
 
 import gift.authorization.dto.TokenResponseDto;
+import gift.member.Member;
 import gift.member.dto.*;
 import gift.member.exception.InvalidMemberException;
 import gift.member.service.MemberService;
+import gift.resolver.LoginMember;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/gift/member/dto/MemberUpdateRequestDto.java
+++ b/src/main/java/gift/member/dto/MemberUpdateRequestDto.java
@@ -5,7 +5,6 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
 public record MemberUpdateRequestDto(
-        Long id,
         @NotBlank(message = "회원명은 필수로 입력해야합니다.")
         @Size(max = 15, message = "회원명은 15자 이내로 입력해야합니다.")
         String name,
@@ -14,6 +13,6 @@ public record MemberUpdateRequestDto(
         String role
 ) {
     public MemberUpdateRequestDto() {
-        this(null, "", "", "");
+        this("", "", "");
     }
 }

--- a/src/main/java/gift/member/repository/MemberRepository.java
+++ b/src/main/java/gift/member/repository/MemberRepository.java
@@ -8,6 +8,7 @@ import java.util.Optional;
 
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
-    Optional<Member> findByEmailAndIdNotIn(String email, Long memberId);
     Optional<Member> findByEmail(String email);
+    boolean existsByEmail(String email);
+    boolean existsByEmailAndIdNotIn(String email, Long memberId);
 }

--- a/src/main/java/gift/member/repository/MemberRepository.java
+++ b/src/main/java/gift/member/repository/MemberRepository.java
@@ -10,5 +10,5 @@ import java.util.Optional;
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByEmail(String email);
     boolean existsByEmail(String email);
-    boolean existsByEmailAndIdNotIn(String email, Long memberId);
+    boolean existsByEmailAndIdNot(String email, Long memberId);
 }

--- a/src/main/java/gift/member/repository/MemberRepository.java
+++ b/src/main/java/gift/member/repository/MemberRepository.java
@@ -8,5 +8,6 @@ import java.util.Optional;
 
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
+    Optional<Member> findByEmailAndIdNotIn(String email, Long memberId);
     Optional<Member> findByEmail(String email);
 }

--- a/src/main/java/gift/member/service/MemberServiceImpl.java
+++ b/src/main/java/gift/member/service/MemberServiceImpl.java
@@ -33,7 +33,7 @@ public class MemberServiceImpl implements MemberService{
 
     @Override
     public void addMember(MemberAddRequestDto requestDto) {
-        validateMemberEmail(requestDto.email(), "admin/memberAdd");
+        validateDuplicateEmail(requestDto.email(), "admin/memberAdd");
         validateMemberRole(requestDto.role(), "admin/memberAdd");
         String hashedPassword = hashWithSHA256(requestDto.password());
         Member member = new Member(requestDto.email(), hashedPassword, requestDto.name(), requestDto.role());
@@ -42,7 +42,7 @@ public class MemberServiceImpl implements MemberService{
 
     @Override
     public TokenResponseDto registerMember(MemberRegisterRequestDto requestDto) {
-        validateMemberEmail(requestDto.email(), "admin/memberAdd");
+        validateDuplicateEmail(requestDto.email(), "admin/memberAdd");
 
         String hashedPassword = hashWithSHA256(requestDto.password());
 
@@ -81,11 +81,9 @@ public class MemberServiceImpl implements MemberService{
     @Override
     @Transactional
     public void updateMemberById(Long id, MemberUpdateRequestDto requestDto) {
-        Member member = findMemberByIdOrElseThrow(id);
-        if (!member.getEmail().equals(requestDto.email())) {
-            validateMemberEmail(requestDto.email(), "admin/memberEdit");
-        }
         validateMemberRole(requestDto.role(), "admin/memberEdit");
+        validateDuplicateEmail(id,requestDto.email(), "admin/memberEdit");
+        Member member = findMemberByIdOrElseThrow(id);
         member.update(requestDto);
     }
 
@@ -95,14 +93,21 @@ public class MemberServiceImpl implements MemberService{
         memberRepository.deleteById(id);
     }
 
-    public void validateMemberEmail(String email, String viewName) {
+    private void validateDuplicateEmail(String email, String viewName) {
         Optional<Member> existing = memberRepository.findByEmail(email);
         if (existing.isPresent()) {
             throw new InvalidMemberException("이미 존재하는 이메일입니다.",viewName,"emailErrorMessage");
         }
     }
 
-    public void validateMemberRole(String role, String viewName) {
+    private void validateDuplicateEmail(Long memberId, String email, String viewName) {
+        Optional<Member> existing = memberRepository.findByEmailAndIdNotIn(email, memberId);
+        if (existing.isPresent()) {
+            throw new InvalidMemberException("이미 존재하는 이메일입니다.",viewName,"emailErrorMessage");
+        }
+    }
+
+    private void validateMemberRole(String role, String viewName) {
         if (!Role.containsIgnoreCase(role)){
             throw new InvalidMemberException("잘못된 등급입니다.", viewName, "roleErrorMessage");
         }

--- a/src/main/java/gift/member/service/MemberServiceImpl.java
+++ b/src/main/java/gift/member/service/MemberServiceImpl.java
@@ -89,20 +89,19 @@ public class MemberServiceImpl implements MemberService{
 
     @Override
     public void deleteMemberById(Long id) {
-        existsByIdOrElseThrow(id);
         memberRepository.deleteById(id);
     }
 
     private void validateDuplicateEmail(String email, String viewName) {
-        Optional<Member> existing = memberRepository.findByEmail(email);
-        if (existing.isPresent()) {
+        boolean existing = memberRepository.existsByEmail(email);
+        if (existing) {
             throw new InvalidMemberException("이미 존재하는 이메일입니다.",viewName,"emailErrorMessage");
         }
     }
 
     private void validateDuplicateEmail(Long memberId, String email, String viewName) {
-        Optional<Member> existing = memberRepository.findByEmailAndIdNotIn(email, memberId);
-        if (existing.isPresent()) {
+        boolean existing = memberRepository.existsByEmailAndIdNotIn(email, memberId);
+        if (existing) {
             throw new InvalidMemberException("이미 존재하는 이메일입니다.",viewName,"emailErrorMessage");
         }
     }

--- a/src/main/java/gift/member/service/MemberServiceImpl.java
+++ b/src/main/java/gift/member/service/MemberServiceImpl.java
@@ -33,7 +33,7 @@ public class MemberServiceImpl implements MemberService{
 
     @Override
     public void addMember(MemberAddRequestDto requestDto) {
-        validateDuplicateEmail(requestDto.email(), "admin/memberAdd");
+        validateUniqueEmail(requestDto.email(), "admin/memberAdd");
         validateMemberRole(requestDto.role(), "admin/memberAdd");
         String hashedPassword = hashWithSHA256(requestDto.password());
         Member member = new Member(requestDto.email(), hashedPassword, requestDto.name(), requestDto.role());
@@ -42,7 +42,7 @@ public class MemberServiceImpl implements MemberService{
 
     @Override
     public TokenResponseDto registerMember(MemberRegisterRequestDto requestDto) {
-        validateDuplicateEmail(requestDto.email(), "admin/memberAdd");
+        validateUniqueEmail(requestDto.email(), "admin/memberAdd");
 
         String hashedPassword = hashWithSHA256(requestDto.password());
 
@@ -82,7 +82,7 @@ public class MemberServiceImpl implements MemberService{
     @Transactional
     public void updateMemberById(Long id, MemberUpdateRequestDto requestDto) {
         validateMemberRole(requestDto.role(), "admin/memberEdit");
-        validateDuplicateEmail(id,requestDto.email(), "admin/memberEdit");
+        validateUniqueEmail(id,requestDto.email(), "admin/memberEdit");
         Member member = findMemberByIdOrElseThrow(id);
         member.update(requestDto);
     }
@@ -92,16 +92,16 @@ public class MemberServiceImpl implements MemberService{
         memberRepository.deleteById(id);
     }
 
-    private void validateDuplicateEmail(String email, String viewName) {
-        boolean existing = memberRepository.existsByEmail(email);
-        if (existing) {
+    private void validateUniqueEmail(String email, String viewName) {
+        boolean isNotUniqueEmail = memberRepository.existsByEmail(email);
+        if (isNotUniqueEmail) {
             throw new InvalidMemberException("이미 존재하는 이메일입니다.",viewName,"emailErrorMessage");
         }
     }
 
-    private void validateDuplicateEmail(Long memberId, String email, String viewName) {
-        boolean existing = memberRepository.existsByEmailAndIdNotIn(email, memberId);
-        if (existing) {
+    private void validateUniqueEmail(Long memberId, String email, String viewName) {
+        boolean isNotUniqueEmail = memberRepository.existsByEmailAndIdNot(email, memberId);
+        if (isNotUniqueEmail) {
             throw new InvalidMemberException("이미 존재하는 이메일입니다.",viewName,"emailErrorMessage");
         }
     }

--- a/src/main/java/gift/product/Product.java
+++ b/src/main/java/gift/product/Product.java
@@ -20,7 +20,6 @@ public class Product {
     }
 
     public Product(String name, Long price, String url) {
-        this.id = id;
         this.name = name;
         this.price = price;
         this.url = url;

--- a/src/main/java/gift/product/controller/ProductController.java
+++ b/src/main/java/gift/product/controller/ProductController.java
@@ -7,11 +7,17 @@ import gift.product.dto.ProductResponseDto;
 import gift.product.exception.InvalidProductException;
 import gift.product.service.ProductService;
 import jakarta.validation.Valid;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/products")
@@ -39,6 +45,20 @@ public class ProductController {
             @PathVariable Long id
     ) {
         ProductResponseDto responseDto = productService.findProductById(id);
+        return new ResponseEntity<>(responseDto, HttpStatus.OK);
+    }
+
+    @GetMapping
+    public ResponseEntity<List<ProductResponseDto>> findAllProducts() {
+        List<ProductResponseDto> responseDto = productService.findAllProducts();
+        return new ResponseEntity<>(responseDto, HttpStatus.OK);
+    }
+
+    @GetMapping("/paged")
+    public ResponseEntity<Page<ProductResponseDto>> findAllProductsWithPageable(
+            @PageableDefault(size = 10, sort = "id", direction = Sort.Direction.DESC) Pageable pageable
+    ) {
+        Page<ProductResponseDto> responseDto = productService.findAllProductsWithPageable(pageable);
         return new ResponseEntity<>(responseDto, HttpStatus.OK);
     }
 

--- a/src/main/java/gift/product/repository/ProductRepository.java
+++ b/src/main/java/gift/product/repository/ProductRepository.java
@@ -1,10 +1,12 @@
 package gift.product.repository;
 
 import gift.product.Product;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ProductRepository extends JpaRepository<Product, Long> {
-
+    Page<Product> findAll(Pageable pageable);
 }

--- a/src/main/java/gift/product/service/ProductService.java
+++ b/src/main/java/gift/product/service/ProductService.java
@@ -4,13 +4,18 @@ import gift.product.Product;
 import gift.product.dto.ProductAddRequestDto;
 import gift.product.dto.ProductResponseDto;
 import gift.product.dto.ProductUpdateRequestDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 
 public interface ProductService {
     void addProduct(ProductAddRequestDto requestDto);
     ProductResponseDto findProductById(Long id);
-    List<ProductResponseDto> findAllProduct();
+    List<ProductResponseDto> findAllProducts();
+
+    Page<ProductResponseDto> findAllProductsWithPageable(Pageable pageable);
+
     void updateProductById(Long id, ProductUpdateRequestDto requestDto);
     void deleteProductById(Long id);
     void validateProductName(String name, String viewName);

--- a/src/main/java/gift/product/service/ProductServiceImpl.java
+++ b/src/main/java/gift/product/service/ProductServiceImpl.java
@@ -7,6 +7,8 @@ import gift.product.dto.ProductUpdateRequestDto;
 import gift.product.exception.InvalidProductException;
 import gift.product.exception.ProductNotFoundException;
 import gift.product.repository.ProductRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -35,10 +37,15 @@ public class ProductServiceImpl implements ProductService {
     }
 
     @Override
-    public List<ProductResponseDto> findAllProduct() {
+    public List<ProductResponseDto> findAllProducts() {
         List<Product> products = productRepository.findAll();
         List<ProductResponseDto> responseDtos = products.stream().map(Product::toProductResponseDto).toList();
         return responseDtos;
+    }
+
+    @Override
+    public Page<ProductResponseDto> findAllProductsWithPageable(Pageable pageable) {
+        return productRepository.findAll(pageable).map(Product::toProductResponseDto);
     }
 
     @Override

--- a/src/main/java/gift/product/service/ProductServiceImpl.java
+++ b/src/main/java/gift/product/service/ProductServiceImpl.java
@@ -58,7 +58,6 @@ public class ProductServiceImpl implements ProductService {
 
     @Override
     public void deleteProductById(Long id) {
-        existsByIdOrElseThrow(id);
         productRepository.deleteById(id);
     }
 

--- a/src/main/java/gift/wishlist/Wishlist.java
+++ b/src/main/java/gift/wishlist/Wishlist.java
@@ -2,6 +2,7 @@ package gift.wishlist;
 
 import gift.member.Member;
 import gift.product.Product;
+import gift.wishlist.dto.WishlistItemResponseDto;
 import jakarta.persistence.*;
 
 @Entity
@@ -25,6 +26,10 @@ public class Wishlist {
         this.member = member;
         this.product = product;
         this.quantity = quantity;
+    }
+
+    public WishlistItemResponseDto toWishlistItemResponseDto(){
+        return new WishlistItemResponseDto(this.id, this.product.getId(), this.quantity);
     }
 
     public void updateQuantity(Long quantity) {

--- a/src/main/java/gift/wishlist/controller/WishlistController.java
+++ b/src/main/java/gift/wishlist/controller/WishlistController.java
@@ -2,10 +2,14 @@ package gift.wishlist.controller;
 
 import gift.member.Member;
 import gift.resolver.LoginMember;
+import gift.wishlist.Wishlist;
 import gift.wishlist.dto.WishlistItemRequestDto;
 import gift.wishlist.dto.WishlistItemResponseDto;
 import gift.wishlist.service.WishlistService;
 import jakarta.validation.Valid;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -35,6 +39,15 @@ public class WishlistController {
             @LoginMember Member member
     ) {
         List<WishlistItemResponseDto> items = wishlistService.findAllWishlistItemsByMemberId(member.getId());
+        return new ResponseEntity<>(items, HttpStatus.OK);
+    }
+
+    @GetMapping("/paged")
+    public ResponseEntity<Page<WishlistItemResponseDto>> findAllWishlistItemsByMemberIdWithPageable(
+            @LoginMember Member member,
+            @PageableDefault(size = 10) Pageable pageable
+    ) {
+        Page<WishlistItemResponseDto> items = wishlistService.findAllWishlistItemsByMemberIdWithPageable(member.getId(), pageable);
         return new ResponseEntity<>(items, HttpStatus.OK);
     }
 

--- a/src/main/java/gift/wishlist/repository/WishlistRepository.java
+++ b/src/main/java/gift/wishlist/repository/WishlistRepository.java
@@ -1,6 +1,8 @@
 package gift.wishlist.repository;
 
 import gift.wishlist.Wishlist;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -12,5 +14,7 @@ public interface WishlistRepository extends JpaRepository<Wishlist, Long> {
 
     List<Wishlist> findAllByMemberId(Long memberId);
     Optional<Wishlist> findByProductIdAndMemberId(Long productId, Long memberId);
+
+    Page<Wishlist> findAllByMemberId(Long memberId, Pageable pageable);
 
 }

--- a/src/main/java/gift/wishlist/service/WishlistService.java
+++ b/src/main/java/gift/wishlist/service/WishlistService.java
@@ -2,6 +2,8 @@ package gift.wishlist.service;
 
 import gift.wishlist.dto.WishlistItemRequestDto;
 import gift.wishlist.dto.WishlistItemResponseDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -13,6 +15,9 @@ public interface WishlistService {
     void deleteWishlistItemById(Long itemId);
 
     List<WishlistItemResponseDto> findAllWishlistItemsByMemberId(Long memberId);
+
+    Page<WishlistItemResponseDto> findAllWishlistItemsByMemberIdWithPageable(Long memberId, Pageable pageable);
+
     void updateWishlistItemById(Long itemId, Long quantity);
 
     void existsByIdOrElseThrow(Long id);

--- a/src/main/java/gift/wishlist/service/WishlistServiceImpl.java
+++ b/src/main/java/gift/wishlist/service/WishlistServiceImpl.java
@@ -46,7 +46,6 @@ public class WishlistServiceImpl implements WishlistService {
 
     @Override
     public void deleteWishlistItemById(Long itemId) {
-        existsByIdOrElseThrow(itemId);
         wishlistRepository.deleteById(itemId);
     }
 

--- a/src/main/java/gift/wishlist/service/WishlistServiceImpl.java
+++ b/src/main/java/gift/wishlist/service/WishlistServiceImpl.java
@@ -2,7 +2,6 @@ package gift.wishlist.service;
 
 import gift.member.Member;
 import gift.member.service.MemberService;
-import gift.product.exception.ProductNotFoundException;
 import gift.product.service.ProductServiceImpl;
 import gift.wishlist.dto.WishlistItemRequestDto;
 import gift.wishlist.dto.WishlistItemResponseDto;
@@ -10,6 +9,8 @@ import gift.product.Product;
 import gift.wishlist.Wishlist;
 import gift.wishlist.exception.WishlistItemNotFoundException;
 import gift.wishlist.repository.WishlistRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -53,8 +54,13 @@ public class WishlistServiceImpl implements WishlistService {
     public List<WishlistItemResponseDto> findAllWishlistItemsByMemberId(Long memberId) {
         List<Wishlist> items = wishlistRepository.findAllByMemberId(memberId);
         return items.stream()
-                .map(item -> new WishlistItemResponseDto(item.getId(), item.getProduct().getId(), item.getQuantity()))
+                .map(Wishlist::toWishlistItemResponseDto)
                 .toList();
+    }
+
+    @Override
+    public Page<WishlistItemResponseDto> findAllWishlistItemsByMemberIdWithPageable(Long memberId, Pageable pageable) {
+        return wishlistRepository.findAllByMemberId(memberId, pageable).map(Wishlist::toWishlistItemResponseDto);
     }
 
     @Override

--- a/src/test/java/gift/repository/ProductRepositoryTest.java
+++ b/src/test/java/gift/repository/ProductRepositoryTest.java
@@ -5,6 +5,9 @@ import gift.product.repository.ProductRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 
 import java.util.Optional;
 
@@ -37,6 +40,22 @@ public class ProductRepositoryTest {
         Optional<Product> deletedProduct = productRepository.findById(product.getId());
 
         assertThat(deletedProduct).isNotPresent();
+    }
+
+    @Test
+    public void 상품_페이지네이션_조회() {
+        for (int i = 1; i <= 30; i++) {
+            productRepository.save(new Product("상품 " + i, (long) i * 100, "url" + i));
+        }
+
+        Pageable pageable = PageRequest.of(0, 10);
+
+        Page<Product> page = productRepository.findAll(pageable);
+
+        assertThat(page.getContent().size()).isEqualTo(10);
+        assertThat(page.getTotalElements()).isEqualTo(34);
+        assertThat(page.getTotalPages()).isEqualTo(4);
+        assertThat(page.getNumber()).isEqualTo(0);
     }
 
 }

--- a/src/test/java/gift/repository/WishlistRepositoryTest.java
+++ b/src/test/java/gift/repository/WishlistRepositoryTest.java
@@ -1,0 +1,87 @@
+package gift.repository;
+
+import gift.member.Member;
+import gift.member.repository.MemberRepository;
+import gift.product.Product;
+import gift.product.repository.ProductRepository;
+import gift.wishlist.Wishlist;
+import gift.wishlist.repository.WishlistRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@DataJpaTest
+public class WishlistRepositoryTest {
+
+    @Autowired
+    private WishlistRepository wishlistRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private ProductRepository productRepository;
+
+    @Test
+    void 위시리스트에_아이템을_저장한다() {
+        Member member = memberRepository.save(new Member("test@email.com", "password", "홍길동", "USER"));
+        Product product = productRepository.save(new Product("초콜릿", 1500L, "http://image"));
+
+        Wishlist wishlist = new Wishlist(member, product, 2L);
+        Wishlist saved = wishlistRepository.save(wishlist);
+
+        assertThat(saved.getId()).isNotNull();
+        assertThat(saved.getQuantity()).isEqualTo(2L);
+    }
+
+    @Test
+    void 위시리스트를_ID로_조회한다() {
+        Member member = memberRepository.save(new Member("kim@email.com", "pass", "김철수", "USER"));
+        Product product = productRepository.save(new Product("사탕", 1000L, "http://image2"));
+
+        Wishlist wishlist = new Wishlist(member, product, 3L);
+        Wishlist saved = wishlistRepository.save(wishlist);
+
+        Optional<Wishlist> found = wishlistRepository.findById(saved.getId());
+        assertThat(found).isPresent();
+        assertThat(found.get().getQuantity()).isEqualTo(3L);
+    }
+
+    @Test
+    void 위시리스트의_수량을_변경한다() {
+        Member member = memberRepository.save(new Member("lee@email.com", "pw", "이영희", "USER"));
+        Product product = productRepository.save(new Product("커피", 3000L, "http://image3"));
+
+        Wishlist wishlist = new Wishlist(member, product, 1L);
+        Wishlist saved = wishlistRepository.save(wishlist);
+
+        saved.updateQuantity(5L);
+        Wishlist updated = wishlistRepository.save(saved);
+
+        assertThat(updated.getQuantity()).isEqualTo(5L);
+    }
+
+    @Test
+    void 페이지네이션으로_위시리스트_조회() {
+        Member member = memberRepository.save(new Member("email@email.com", "pw", "이름", "USER"));
+
+        for (int i = 1; i <= 25; i++) {
+            Product product = productRepository.save(new Product("상품" + i, 1000L * i, "http://url.com/" + i));
+            wishlistRepository.save(new Wishlist(member, product, (long) i));
+        }
+
+        PageRequest pageRequest = PageRequest.of(0, 10); // 첫 페이지, 10개
+        Page<Wishlist> wishlistPage = wishlistRepository.findAllByMemberId(member.getId(), pageRequest);
+
+        assertThat(wishlistPage.getContent().size()).isEqualTo(10);
+        assertThat(wishlistPage.getTotalElements()).isEqualTo(25);
+        assertThat(wishlistPage.getTotalPages()).isEqualTo(3);
+    }
+}


### PR DESCRIPTION
# 멘토님께
1. 멘토님께서 주신 피드백에 대해 생각해보고 반영하였습니다.

2. 2단계 미션으로 Product와 Wishlist에 페이지네이션을 적용하였습니다.

3.
페이지네이션을 적용하면서 
findAllWithPageable메서드를 새로 만들고
"/paged" url에 get매핑하였습니다.

이처럼 전체조회 메서드와 페이징을 사용한 전체조회 메서드를 
구분해서 다루어야하는지,
하나로 합쳐야 하는지 의문이 듭니다.

4.
명일부터 주말을 거쳐
로그인 뷰와 상품선택뷰, 위시리스트 뷰를 구현하려고 합니다.

그러기 전에 고민이 되는 부분이
멘토님이 말씀하신 것처럼
멤버정보 update메서드에 토큰을 받아 처리하는 로직이 없습니다.
현재는 관리자페이지에서만 수정 가능하다고 가정하고 만들었기 때문입니다.

그러나 이번에 뷰를 만들면서
멤버정보 update를 요청하는 사용자가
admin일수도 있고 user일 수도 있는데
두 사용자가 요청할때 동작하는 update메서드를 각각 따로따로 만들어야하는지
update메서드에 요청한 사용자의 정보 확인 로직을 넣어
본인과 admin만 수정가능하게 해야하는지 의문이 듭니다.

또한, 상품 추가, 삭제, 수정 api에도
admin인지 확인하는 로직을 넣어야 하는지 의문이 듭니다.
 
# 동작사진
<img width="1284" height="829" alt="image" src="https://github.com/user-attachments/assets/a84d8df6-d8fc-44c9-8ac3-8cca51069968" />
