### PR TITLE
Step2

### DIFF
--- a/src/main/java/gift/controller/AdminProductController.java
+++ b/src/main/java/gift/controller/AdminProductController.java
@@ -4,6 +4,8 @@ import gift.domain.Product;
 import gift.dto.ProductRequest;
 import gift.service.ProductService;
 import jakarta.validation.Valid;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
@@ -22,8 +24,9 @@ public class AdminProductController {
     }
 
     @GetMapping
-    public String list(Model model) {
-        model.addAttribute("products", productService.findAll());
+    public String list(Model model, Pageable pageable) {
+        Page<Product> products = productService.findAll(pageable);
+        model.addAttribute("products", products);
         return "product/list";
     }
 

--- a/src/main/java/gift/controller/ProductController.java
+++ b/src/main/java/gift/controller/ProductController.java
@@ -4,11 +4,11 @@ import gift.domain.Product;
 import gift.dto.ProductRequest;
 import gift.service.ProductService;
 import jakarta.validation.Valid;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 @RestController
 @RequestMapping("/api/products")
@@ -21,8 +21,8 @@ public class ProductController {
     }
 
     @GetMapping
-    public List<Product> getAll() {
-        return productService.findAll();
+    public Page<Product> getAll(Pageable pageable) {
+        return productService.findAll(pageable);
     }
 
     @GetMapping("/{id}")

--- a/src/main/java/gift/controller/WishController.java
+++ b/src/main/java/gift/controller/WishController.java
@@ -2,8 +2,8 @@ package gift.controller;
 
 import gift.auth.LoginMember;
 import gift.domain.Member;
-import gift.domain.Product;
 import gift.dto.WishRequest;
+import gift.dto.WishResponse;
 import gift.service.WishService;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -21,7 +21,7 @@ public class WishController {
     }
 
     @GetMapping
-    public Page<Product> getMyWishes(@LoginMember Member member, Pageable pageable) {
+    public Page<WishResponse> getMyWishes(@LoginMember Member member, Pageable pageable) {
         return wishService.getWishList(member.getId(), pageable);
     }
 

--- a/src/main/java/gift/controller/WishController.java
+++ b/src/main/java/gift/controller/WishController.java
@@ -5,10 +5,10 @@ import gift.domain.Member;
 import gift.domain.Product;
 import gift.dto.WishRequest;
 import gift.service.WishService;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 @RestController
 @RequestMapping("/api/wishes")
@@ -21,8 +21,8 @@ public class WishController {
     }
 
     @GetMapping
-    public List<Product> getMyWishes(@LoginMember Member member) {
-        return wishService.getWishList(member.getId());
+    public Page<Product> getMyWishes(@LoginMember Member member, Pageable pageable) {
+        return wishService.getWishList(member.getId(), pageable);
     }
 
     @PostMapping

--- a/src/main/java/gift/repository/ProductRepository.java
+++ b/src/main/java/gift/repository/ProductRepository.java
@@ -2,6 +2,8 @@ package gift.repository;
 
 import gift.domain.Product;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface ProductRepository extends JpaRepository<Product, Long> {
 }

--- a/src/main/java/gift/repository/WishRepository.java
+++ b/src/main/java/gift/repository/WishRepository.java
@@ -4,12 +4,15 @@ import gift.domain.Wish;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
-
 import java.util.Optional;
 
 @Repository
 public interface WishRepository extends JpaRepository<Wish, Long> {
+    @Query("SELECT w FROM Wish w LEFT JOIN FETCH w.product WHERE w.member.id = :memberId")
+    Page<Wish> findByMemberIdWithProduct(Long memberId, Pageable pageable);
+
     Page<Wish> findByMemberId(Long memberId, Pageable pageable);
     Optional<Wish> findByMemberIdAndProductId(Long memberId, Long productId);
     void deleteByMemberIdAndProductId(Long memberId, Long productId);

--- a/src/main/java/gift/repository/WishRepository.java
+++ b/src/main/java/gift/repository/WishRepository.java
@@ -1,13 +1,16 @@
 package gift.repository;
 
 import gift.domain.Wish;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
-import java.util.List;
 import java.util.Optional;
 
+@Repository
 public interface WishRepository extends JpaRepository<Wish, Long> {
-    List<Wish> findByMemberId(Long memberId);
+    Page<Wish> findByMemberId(Long memberId, Pageable pageable);
     Optional<Wish> findByMemberIdAndProductId(Long memberId, Long productId);
     void deleteByMemberIdAndProductId(Long memberId, Long productId);
 }

--- a/src/main/java/gift/service/ProductService.java
+++ b/src/main/java/gift/service/ProductService.java
@@ -33,15 +33,12 @@ public class ProductService {
         return repo.save(product);
     }
 
-    public boolean update(Long id, Product product) {
-        Product target = repo.findById(id).orElse(null);
-        if (target == null) {
-            return false;
-        }
+    public void update(Long id, Product product) {
+        Product target = repo.findById(id)
+            .orElseThrow(() -> new IllegalArgumentException("Product not found with id: " + id));
         target.setName(product.getName());
         target.setPrice(product.getPrice());
         target.setImageUrl(product.getImageUrl());
-        return true;
     }
 
     public boolean delete(Long id) {

--- a/src/main/java/gift/service/ProductService.java
+++ b/src/main/java/gift/service/ProductService.java
@@ -2,10 +2,11 @@ package gift.service;
 
 import gift.domain.Product;
 import gift.repository.ProductRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
 import java.util.Optional;
 
 //
@@ -20,8 +21,8 @@ public class ProductService {
     }
 
 
-    public List<Product> findAll() {
-        return repo.findAll();
+    public Page<Product> findAll(Pageable pageable) {
+        return repo.findAll(pageable);
     }
 
     public Optional<Product> findById(Long id) {
@@ -32,15 +33,22 @@ public class ProductService {
         return repo.save(product);
     }
 
-    public Product update(Long id, Product product) {
-        Product target = repo.findById(id).orElseThrow(() -> new IllegalArgumentException("해당 상품을 찾을 수 없습니다."));
+    public boolean update(Long id, Product product) {
+        Product target = repo.findById(id).orElse(null);
+        if (target == null) {
+            return false;
+        }
         target.setName(product.getName());
         target.setPrice(product.getPrice());
         target.setImageUrl(product.getImageUrl());
-        return target;
+        return true;
     }
 
-    public void delete(Long id) {
-        repo.deleteById(id);
+    public boolean delete(Long id) {
+        if (repo.existsById(id)) {
+            repo.deleteById(id);
+            return true;
+        }
+        return false;
     }
 }

--- a/src/main/java/gift/service/WishService.java
+++ b/src/main/java/gift/service/WishService.java
@@ -12,8 +12,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 @Transactional
@@ -29,9 +27,9 @@ public class WishService {
         this.productRepository = productRepository;
     }
 
-    public Page<Product> getWishList(Long memberId, Pageable pageable) {
-        return wishRepository.findByMemberId(memberId, pageable)
-            .map(Wish::getProduct);
+    public Page<gift.dto.WishResponse> getWishList(Long memberId, Pageable pageable) {
+        return wishRepository.findByMemberIdWithProduct(memberId, pageable)
+            .map(gift.dto.WishResponse::from);
     }
 
     public void addWish(Long memberId, WishRequest wishRequest) {

--- a/src/main/java/gift/service/WishService.java
+++ b/src/main/java/gift/service/WishService.java
@@ -7,6 +7,8 @@ import gift.dto.WishRequest;
 import gift.repository.MemberRepository;
 import gift.repository.ProductRepository;
 import gift.repository.WishRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -27,10 +29,9 @@ public class WishService {
         this.productRepository = productRepository;
     }
 
-    public List<Product> getWishList(Long memberId) {
-        return wishRepository.findByMemberId(memberId).stream()
-            .map(Wish::getProduct)
-            .collect(Collectors.toList());
+    public Page<Product> getWishList(Long memberId, Pageable pageable) {
+        return wishRepository.findByMemberId(memberId, pageable)
+            .map(Wish::getProduct);
     }
 
     public void addWish(Long memberId, WishRequest wishRequest) {


### PR DESCRIPTION
 **상품 페이지네이션:**
         - `ProductRepository`가 이제 Spring Data의 페이지네이션을 활용하기 위해 `JpaRepository`를 상속합니다.
         - `ProductService.findAll()`이 이제 `Pageable` 객체를 받아 `Page<Product>`를 반환합니다.
         - `ProductController.getAll()` 및 `AdminProductController.list()`가 이제 페이지네이션을 지원하기 위해 `Pageable`을
      매개변수로 받습니다.
     
    - **위시리스트 페이지네이션:**
        - `WishRepository`가 이제 `JpaRepository`를 상속하며, `Pageable`을 받는 `findByMemberId` 메서드를 포함합니다.
        - `WishService.getWishList()`가 이제 `Pageable` 객체를 받아 `Page<Product>`를 반환합니다.
        - `WishController.getMyWishes()`가 이제 `Pageable`을 매개변수로 받습니다.
   
    - **리팩토링 및 수정:**
        - `ProductRepository` 및 `WishRepository`의 패키지 임포트를 수정했습니다.
        - `ProductService.update()` 및 `ProductService.delete()`가 일관성을 위해 `boolean`을 반환하도록 수정했습니다.
        - 변경 사항을 반영하고 테스트가 통과하도록 `WishRepositoryTest` 및 `MemberRepositoryTest`를 업데이트했습니다.

