### PR TITLE
강원대 BE_이시행 2단계 - 페이지네이션

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,9 @@
 1. products, users 테이블 매핑을 위한 entity 변경 및 이에 따른 service, repository 레이어 수정
 2. wishes 테이블 매핑을 위한 entity 변경 및 이에 따른 3레이어 수정 및 예외 수정
 3. JPA 테스트 작성
+
+# 페이지네이션
+1. Products 조회 페이지네이션 적용
+2. wishes 유저별 조회 페이지네이션 적용
+3. Products 관리 화면 페이지 이동 버튼 추가
+4. 테스트 코드 수정

--- a/src/main/java/gift/controller/AdminController.java
+++ b/src/main/java/gift/controller/AdminController.java
@@ -9,7 +9,6 @@ import gift.service.UserService;
 import gift.service.ProductService;
 import jakarta.validation.Valid;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.data.web.SortDefault;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
@@ -37,7 +36,7 @@ public class AdminController {
      */
     @GetMapping("/products")
     public String showProductsList(
-            @SortDefault(sort = "id", direction = Sort.Direction.DESC)
+            @SortDefault(sort = "id")
             Pageable pageable,
             Model model) {
         model.addAttribute("products", productService.findAllProduct(pageable));

--- a/src/main/java/gift/controller/AdminController.java
+++ b/src/main/java/gift/controller/AdminController.java
@@ -8,6 +8,9 @@ import gift.service.AuthService;
 import gift.service.UserService;
 import gift.service.ProductService;
 import jakarta.validation.Valid;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.SortDefault;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.ui.Model;
@@ -33,8 +36,11 @@ public class AdminController {
      * @return Thymeleaf template
      */
     @GetMapping("/products")
-    public String showProductsList(Model model) {
-        model.addAttribute("products", productService.findAllProduct());
+    public String showProductsList(
+            @SortDefault(sort = "id", direction = Sort.Direction.DESC)
+            Pageable pageable,
+            Model model) {
+        model.addAttribute("products", productService.findAllProduct(pageable));
         return "products_list";
     }
 

--- a/src/main/java/gift/controller/ProductController.java
+++ b/src/main/java/gift/controller/ProductController.java
@@ -4,11 +4,13 @@ import gift.dto.ProductRequestDto;
 import gift.dto.ProductResponseDto;
 import gift.service.ProductService;
 import jakarta.validation.Valid;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.SortDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 @RestController
 @RequestMapping("/products")
@@ -32,11 +34,13 @@ public class ProductController {
 
     /*
      * 제품 모두 조회
-     * @return : List<ProductResponseDto> JSON
+     * @return : Page<ProductResponseDto> JSON
      */
     @GetMapping()
-    public ResponseEntity<List<ProductResponseDto>> findAllProducts(){
-        return new ResponseEntity<>(productService.findAllProduct(), HttpStatus.OK);
+    public ResponseEntity<Page<ProductResponseDto>> findAllProducts(
+            @SortDefault(sort = "id", direction = Sort.Direction.DESC)
+            Pageable pageable){
+        return new ResponseEntity<>(productService.findAllProduct(pageable), HttpStatus.OK);
     }
 
     /*

--- a/src/main/java/gift/controller/ProductController.java
+++ b/src/main/java/gift/controller/ProductController.java
@@ -6,7 +6,6 @@ import gift.service.ProductService;
 import jakarta.validation.Valid;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.data.web.SortDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -38,7 +37,7 @@ public class ProductController {
      */
     @GetMapping()
     public ResponseEntity<Page<ProductResponseDto>> findAllProducts(
-            @SortDefault(sort = "id", direction = Sort.Direction.DESC)
+            @SortDefault(sort = "id")
             Pageable pageable){
         return new ResponseEntity<>(productService.findAllProduct(pageable), HttpStatus.OK);
     }

--- a/src/main/java/gift/controller/WishController.java
+++ b/src/main/java/gift/controller/WishController.java
@@ -27,18 +27,18 @@ public class WishController {
     }
 
     @PostMapping()
-    public ResponseEntity<WishResponseDto> addWish(@UserValid UserInfoDto userInfoDto, @RequestBody WishRequestDto wishRequestDto) {
+    public ResponseEntity<WishResponseDto> add(@UserValid UserInfoDto userInfoDto, @RequestBody WishRequestDto wishRequestDto) {
         return new ResponseEntity<>(wishService.addWish(userInfoDto, wishRequestDto), HttpStatus.CREATED);
     }
 
     @PatchMapping()
-    public ResponseEntity<Void> updateWish(@UserValid UserInfoDto userInfoDto, @RequestBody WishRequestDto wishrequestDto) {
+    public ResponseEntity<Void> update(@UserValid UserInfoDto userInfoDto, @RequestBody WishRequestDto wishrequestDto) {
         wishService.updateWish(wishrequestDto);
         return ResponseEntity.noContent().build();
     }
 
     @DeleteMapping()
-    public ResponseEntity<Void> deleteWish(@UserValid UserInfoDto userInfoDto, @RequestBody WishRequestDto wishRequestDto) {
+    public ResponseEntity<Void> delete(@UserValid UserInfoDto userInfoDto, @RequestBody WishRequestDto wishRequestDto) {
         wishService.deleteWish(wishRequestDto);
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/gift/controller/WishController.java
+++ b/src/main/java/gift/controller/WishController.java
@@ -5,11 +5,12 @@ import gift.dto.UserInfoDto;
 import gift.dto.WishRequestDto;
 import gift.dto.WishResponseDto;
 import gift.service.WishService;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.SortDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 @RestController
 @RequestMapping("/wish")
@@ -22,8 +23,11 @@ public class WishController {
     }
 
     @GetMapping()
-    public ResponseEntity<List<WishResponseDto>> findUserWishes(@UserValid UserInfoDto userInfoDto) {
-        return ResponseEntity.ok(wishService.findUserWishes(userInfoDto));
+    public ResponseEntity<Page<WishResponseDto>> findUserWishes(
+            @UserValid UserInfoDto userInfoDto,
+            @SortDefault(sort = "id")
+            Pageable pageable) {
+        return ResponseEntity.ok(wishService.findUserWishes(userInfoDto, pageable));
     }
 
     @PostMapping()

--- a/src/main/java/gift/entity/Wish.java
+++ b/src/main/java/gift/entity/Wish.java
@@ -17,8 +17,7 @@ public class Wish {
 
     protected Wish() {}
 
-    public Wish(Long id, Long userId, Long productId, Long quantity) {
-        this.id = id;
+    public Wish(Long userId, Long productId, Long quantity) {
         this.userId = userId;
         this.productId = productId;
         this.quantity = quantity;

--- a/src/main/java/gift/repository/WishRepository.java
+++ b/src/main/java/gift/repository/WishRepository.java
@@ -1,13 +1,13 @@
 package gift.repository;
 
 import gift.entity.Wish;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import java.util.Collection;
-
 @Repository
 public interface WishRepository extends JpaRepository<Wish, Long> {
-    Collection<Wish> findByUserId(Long userId);
+    Page<Wish> findByUserId(Long userId, Pageable pageable);
     boolean existsByProductId(Long productId);
 }

--- a/src/main/java/gift/service/ProductService.java
+++ b/src/main/java/gift/service/ProductService.java
@@ -7,12 +7,13 @@ import gift.exception.InvalidProductNameException;
 import gift.repository.ProductRepository;
 import jakarta.transaction.Transactional;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import gift.exception.NotFoundException;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 public class ProductService {
@@ -37,8 +38,8 @@ public class ProductService {
     }
 
     @Transactional
-    public List<ProductResponseDto> findAllProduct(){
-        return productRepository.findAll().stream().map(ProductResponseDto::new).collect(Collectors.toList());
+    public Page<ProductResponseDto> findAllProduct(Pageable pageable){
+        return productRepository.findAll(pageable).map(ProductResponseDto::new);
     }
 
     @Transactional

--- a/src/main/java/gift/service/WishService.java
+++ b/src/main/java/gift/service/WishService.java
@@ -29,7 +29,7 @@ public class WishService {
             throw new DuplicateException("이미 리스트에 존재하는 제품입니다.");
         }
 
-        Wish wish = new Wish(wishRequestDto.id(), userInfoDto.id(), wishRequestDto.productId(), wishRequestDto.quantity());
+        Wish wish = new Wish(userInfoDto.id(), wishRequestDto.productId(), wishRequestDto.quantity());
         return new WishResponseDto(wishRepository.save(wish));
     }
 

--- a/src/main/java/gift/service/WishService.java
+++ b/src/main/java/gift/service/WishService.java
@@ -7,10 +7,9 @@ import gift.entity.Wish;
 import gift.exception.DuplicateException;
 import gift.exception.NotFoundException;
 import gift.repository.WishRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
-
-import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 public class WishService {
@@ -21,8 +20,8 @@ public class WishService {
         this.wishRepository = wishRepository;
     }
 
-    public List<WishResponseDto> findUserWishes(UserInfoDto userInfoDto) {
-        return wishRepository.findByUserId(userInfoDto.id()).stream().map(WishResponseDto::new).collect(Collectors.toList());
+    public Page<WishResponseDto> findUserWishes(UserInfoDto userInfoDto, Pageable pageable) {
+        return wishRepository.findByUserId(userInfoDto.id(), pageable).map(WishResponseDto::new);
     }
 
     public WishResponseDto addWish(UserInfoDto userInfoDto, WishRequestDto wishRequestDto) {

--- a/src/main/resources/templates/products_list.html
+++ b/src/main/resources/templates/products_list.html
@@ -13,11 +13,12 @@
     <table class="table table-bordered">
         <thead>
         <tr>
-            <th>ID</th><th>Name</th><th>Price</th><th>ImageUrl</th>
+            <th>ID</th><th>Name</th><th>Price</th><th>ImageUrl</th><th>Actions</th>
         </tr>
         </thead>
         <tbody>
-        <tr th:each="product : ${products}">
+        <!-- products가 Page<ProductDto> 객체라면 content로 반복 -->
+        <tr th:each="product : ${products.content}">
             <td th:text="${product.id}">Product id</td>
             <td th:text="${product.name}">Product name</td>
             <td th:text="${product.price}">product price</td>
@@ -31,6 +32,35 @@
         </tr>
         </tbody>
     </table>
+
+    <nav th:if="${products.totalPages > 1}">
+        <ul class="pagination">
+            <li class="page-item" th:classappend="${!products.hasPrevious()} ? ' disabled'">
+                <a class="page-link"
+                   th:href="@{/admin/products(page=${products.number - 1},size=${products.size})}"
+                   aria-label="Previous">
+                    <span aria-hidden="true">&laquo;</span>
+                </a>
+            </li>
+
+            <li class="page-item"
+                th:each="i : ${#numbers.sequence(0, products.totalPages - 1)}"
+                th:classappend="${i == products.number} ? ' active'">
+                <a class="page-link"
+                   th:href="@{/admin/products(page=${i},size=${products.size})}"
+                   th:text="${i + 1}">1</a>
+            </li>
+
+            <li class="page-item" th:classappend="${!products.hasNext()} ? ' disabled'">
+                <a class="page-link"
+                   th:href="@{/admin/products(page=${products.number+1},size=${products.size})}"
+                   aria-label="Next">
+                    <span aria-hidden="true">&raquo;</span>
+                </a>
+            </li>
+        </ul>
+    </nav>
+
 </div>
 </body>
 </html>

--- a/src/test/java/gift/controller/AdminControllerTest.java
+++ b/src/test/java/gift/controller/AdminControllerTest.java
@@ -1,6 +1,5 @@
 package gift.controller;
 
-import gift.controller.AdminController;
 import gift.dto.ProductRequestDto;
 import gift.dto.ProductResponseDto;
 import gift.dto.UserRequestDto;
@@ -12,6 +11,10 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
@@ -43,21 +46,29 @@ class AdminControllerTest {
     @MockitoBean
     private UserService userService;
 
+    @MockitoBean
+    private org.springframework.data.jpa.mapping.JpaMetamodelMappingContext jpaMappingContext;
+    @MockitoBean
+    private org.springframework.data.auditing.AuditingHandler jpaAuditingHandler;
+
     //////////////////////////////////////////////   Products   /////////////////////////////////////////////
 
     @Test
     @DisplayName("관리자 제품 리스트 보기 – 200 OK, 'products' 모델 속성")
     void showProductsList() throws Exception {
+        var pageable = PageRequest.of(0, 20);
         var products = List.of(
                 new ProductResponseDto(1L, "A", 1000L, "urlA"),
                 new ProductResponseDto(2L, "B", 2000L, "urlB")
         );
-        when(productService.findAllProduct()).thenReturn(products);
+        Page<ProductResponseDto> page = new PageImpl<>(products, pageable, products.size());
+
+        when(productService.findAllProduct(any(Pageable.class))).thenReturn(page);
 
         mockMvc.perform(get("/admin/products"))
                 .andExpect(status().isOk())
                 .andExpect(view().name("products_list"))
-                .andExpect(model().attribute("products", products));
+                .andExpect(model().attribute("products", page));
     }
 
     @Test

--- a/src/test/java/gift/controller/AuthControllerTest.java
+++ b/src/test/java/gift/controller/AuthControllerTest.java
@@ -1,7 +1,6 @@
 package gift.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import gift.controller.AuthController;
 import gift.dto.UserRequestDto;
 import gift.dto.UserResponseDto;
 import gift.dto.TokenResponseDto;
@@ -32,6 +31,11 @@ class AuthControllerTest {
 
     @MockitoBean
     private AuthService authService;
+
+    @MockitoBean
+    private org.springframework.data.jpa.mapping.JpaMetamodelMappingContext jpaMappingContext;
+    @MockitoBean
+    private org.springframework.data.auditing.AuditingHandler jpaAuditingHandler;
 
     @Test
     @DisplayName("회원가입 성공 – 201 CREATED, UserResponseDto 검증")

--- a/src/test/java/gift/controller/ProductControllerTest.java
+++ b/src/test/java/gift/controller/ProductControllerTest.java
@@ -1,7 +1,6 @@
 package gift.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import gift.controller.ProductController;
 import gift.dto.ProductRequestDto;
 import gift.dto.ProductResponseDto;
 import gift.service.ProductService;
@@ -9,6 +8,10 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
@@ -34,6 +37,11 @@ class ProductControllerTest {
     @Autowired
     private ObjectMapper objectMapper;
 
+    @MockitoBean
+    private org.springframework.data.jpa.mapping.JpaMetamodelMappingContext jpaMappingContext;
+    @MockitoBean
+    private org.springframework.data.auditing.AuditingHandler jpaAuditingHandler;
+
     @Test
     @DisplayName("제품 단건 조회 – 200 OK")
     void findProductById() throws Exception {
@@ -53,17 +61,19 @@ class ProductControllerTest {
     @Test
     @DisplayName("모든 제품 조회 – 200 OK")
     void findAllProducts() throws Exception {
+        var pageable = PageRequest.of(0, 20);
         var list = List.of(
                 new ProductResponseDto(1L, "A", 100L, "http://img.url/a.png"),
                 new ProductResponseDto(2L, "B", 200L, "http://img.url/b.png")
         );
-        when(productService.findAllProduct()).thenReturn(list);
+        Page<ProductResponseDto> page = new PageImpl<>(list, pageable, list.size());
+
+        when(productService.findAllProduct(any(Pageable.class))).thenReturn(page);
 
         mockMvc.perform(get("/products"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.length()").value(2))
-                .andExpect(jsonPath("$[0].imageUrl").value("http://img.url/a.png"))
-                .andExpect(jsonPath("$[1].imageUrl").value("http://img.url/b.png"));
+                .andExpect(jsonPath("content.[0].imageUrl").value("http://img.url/a.png"))
+                .andExpect(jsonPath("content.[1].imageUrl").value("http://img.url/b.png"));
     }
 
     @Test

--- a/src/test/java/gift/repository/ProductRepositoryTest.java
+++ b/src/test/java/gift/repository/ProductRepositoryTest.java
@@ -4,9 +4,15 @@ import gift.entity.Product;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.assertj.core.api.Assertions.tuple;
 
 @DataJpaTest
 public class ProductRepositoryTest {
@@ -28,7 +34,41 @@ public class ProductRepositoryTest {
     @Test
     void findById() {
         Product product1 = productRepository.save(new Product("과자", 1000L, "http://snack"));
-        Product product2 = productRepository.findById(1L).orElse(null);
+        Product product2 = productRepository.findById(product1.getId()).orElse(null);
         assertThat(product1).isEqualTo(product2);
+    }
+
+    @Test
+    void sortByIdAsc() {
+        productRepository.save(new Product("B", 2000L, "u2"));
+        productRepository.save(new Product("C", 3000L, "u1"));
+        productRepository.save(new Product("A", 1000L, "u3"));
+        Page<Product> page = productRepository.findAll(
+                PageRequest.of(0, 20, Sort.by(Sort.Direction.ASC, "id"))
+        );
+
+        List<Product> products = page.getContent();
+        assertThat(products.stream().map(Product::getId).toList())
+                .containsExactly(6L,7L,8L);
+    }
+
+    @Test
+    void sortByPriceDescThenNameAsc() {
+        productRepository.save(new Product("B", 2000L, "u2"));
+        productRepository.save(new Product("A", 3000L, "u1"));
+        productRepository.save(new Product("A", 1000L, "u3"));
+
+        Page<Product> page = productRepository.findAll(
+                PageRequest.of(0, 20,
+                        Sort.by(Sort.Order.desc("price"), Sort.Order.asc("name")))
+        );
+
+        assertThat(page.getContent())
+                .extracting(Product::getPrice, Product::getName)
+                .containsExactly(
+                        tuple(3000L, "A"),
+                        tuple(2000L, "B"),
+                        tuple(1000L, "A")
+                );
     }
 }

--- a/src/test/java/gift/repository/WishRepositoryTest.java
+++ b/src/test/java/gift/repository/WishRepositoryTest.java
@@ -5,9 +5,15 @@ import gift.entity.Wish;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.assertj.core.api.Assertions.tuple;
 
 @DataJpaTest
 public class WishRepositoryTest {
@@ -38,5 +44,39 @@ public class WishRepositoryTest {
         Wish wish1 = wishRepository.save(new Wish(new WishRequestDto(1L, 3L)));
         boolean flag = wishRepository.existsByProductId(wish1.getId());
         assertThat(flag).isFalse();
+    }
+
+    @Test
+    void sortByUserIdAsc() {
+        wishRepository.save(new Wish(2L, 3L, 3L));
+        wishRepository.save(new Wish(1L, 3L, 3L));
+        wishRepository.save(new Wish(3L, 3L, 3L));
+        Page<Wish> page = wishRepository.findAll(
+                PageRequest.of(0, 20, Sort.by(Sort.Direction.ASC, "userId"))
+        );
+
+        List<Wish> wishes = page.getContent();
+        assertThat(wishes.stream().map(Wish::getUserId).toList())
+                .containsExactly(1L,2L,3L);
+    }
+
+    @Test
+    void sortByQuantityDescThenIdAsc() {
+        wishRepository.save(new Wish(3L, 3L, 2L));
+        wishRepository.save(new Wish(3L, 3L, 2L));
+        wishRepository.save(new Wish(3L, 3L, 3L));
+
+        Page<Wish> page = wishRepository.findAll(
+                PageRequest.of(0, 20,
+                        Sort.by(Sort.Order.desc("quantity"), Sort.Order.asc("id")))
+        );
+
+        assertThat(page.getContent())
+                .extracting(Wish::getQuantity, Wish::getId)
+                .containsExactly(
+                        tuple(3L, 5L),
+                        tuple(2L, 3L),
+                        tuple(2L, 4L)
+                );
     }
 }


### PR DESCRIPTION
상품 목록, 위시 리스트 조회에 페이지네이션 구현했습니다. 정렬 기준은 id, 오름차순입니다.
기존에 만들었던 상품 관리 페이지도 이에 맞춰 업데이트 했으며  페이지 이동 버튼도 추가했습니다.

<img width="1157" height="777" alt="image" src="https://github.com/user-attachments/assets/f067040a-6226-44b3-a2b9-be467f37c51a" />

20개 미만의 상품이 있을 때는 페이지 이동 버튼이 나타나지 않지만



<img width="1199" height="261" alt="image" src="https://github.com/user-attachments/assets/dd74d0e1-b966-4a5d-aeac-d7a95adbf198" />

20개를 초과하면 페이지 이동 버튼이 나타납니다.

위시 리스트 관리 페이지도 만들어볼까 생각해보았지만 "관리자가 개인의 위시 리스트를 관리할 필요가 있을까...?" 라는 의문이 들어 프론트엔드의 영역이라 판단하고 보류했습니다.