### PR TITLE
부산대 BE_오선재 Step3 - 상품 옵션

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,3 +106,53 @@ CONSTRAINT fk_wish_product FOREIGN KEY (product_id) REFERENCES products(id)
   - 페이지 인덱스와 한 페이지에 표시할 아이템 수만 노출  
 
 ---
+
+## 🚀 Step 3 – 상품 옵션
+
+### 🎯 기능 요구사항 체크리스트
+
+- [ ] **옵션 조회 API**
+  - 엔드포인트:
+    ```http
+    GET /api/products/{productId}/options
+    ```  
+  - 응답:
+    - HTTP 200
+    - `application/json`
+    - Body: 옵션 객체 배열
+      ```json
+      [
+        {
+          "id": 123,
+          "name": "기본형",
+          "quantity": 100
+        },
+        ...
+      ]
+      ```
+- [ ] **옵션 수량 차감 기능**
+  - 서비스 계층 메서드(`OptionService.subtract`)로 구현
+  - 별도의 HTTP API는 선택 사항
+  - 재고(`quantity`)가 부족할 경우 예외 발생
+- [ ] **옵션 이름 제약**
+  - 공백 포함 **1~50자**
+  - 허용 특수문자: `()`, `.`, `[`, `]`, `+`, `-`, `&`, `/`, `_`
+  - 그 외 특수문자 사용 불가
+- [ ]**옵션 수량 제약**
+  - 최소 **1개 이상**, 최대 **1억 미만**
+- [ ]**중복 옵션 이름 금지**
+  - 동일 상품 내에서 옵션 이름 중복 불허
+- [ ] **(선택) 관리자 화면에서 옵션 추가/삭제 UI 제공**
+  - Thymeleaf 템플릿(`templates/products/optionForm.html`) + 뷰 컨트롤러 구현
+
+### ⚙️ 프로그래밍 요구 사항
+- `Option` 엔티티: `id`, `name(1~50자)`, `quantity(1~1억 미만)`, `product(FK)`
+  - 동일 상품 내 옵션 이름 중복 방지를 위한 `UNIQUE (product_id, name)`
+- `OptionRepository`: `findAllByProductId`, `findByProductIdAndName` 등
+
+### 🧪 테스트
+- Repository: 저장·조회·UNIQUE 검증
+- Service: 재고 차감·부족 예외
+- Controller: GET 200 / 수량 차감 실패 400 / 재고 부족 409
+
+---

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ CONSTRAINT fk_wish_product FOREIGN KEY (product_id) REFERENCES products(id)
 
 ### 🎯 기능 요구사항 체크리스트
 
-- [ ] **옵션 조회 API**
+- [x] **옵션 조회 API**
   - 엔드포인트:
     ```http
     GET /api/products/{productId}/options
@@ -130,17 +130,17 @@ CONSTRAINT fk_wish_product FOREIGN KEY (product_id) REFERENCES products(id)
         ...
       ]
       ```
-- [ ] **옵션 수량 차감 기능**
+- [x] **옵션 수량 차감 기능**
   - 서비스 계층 메서드(`OptionService.subtract`)로 구현
   - 별도의 HTTP API는 선택 사항
   - 재고(`quantity`)가 부족할 경우 예외 발생
-- [ ] **옵션 이름 제약**
+- [x] **옵션 이름 제약**
   - 공백 포함 **1~50자**
   - 허용 특수문자: `()`, `.`, `[`, `]`, `+`, `-`, `&`, `/`, `_`
   - 그 외 특수문자 사용 불가
-- [ ]**옵션 수량 제약**
+- [x] **옵션 수량 제약**
   - 최소 **1개 이상**, 최대 **1억 미만**
-- [ ]**중복 옵션 이름 금지**
+- [x] **중복 옵션 이름 금지**
   - 동일 상품 내에서 옵션 이름 중복 불허
 - [ ] **(선택) 관리자 화면에서 옵션 추가/삭제 UI 제공**
   - Thymeleaf 템플릿(`templates/products/optionForm.html`) + 뷰 컨트롤러 구현

--- a/src/main/java/gift/config/OperationSeparatorAspect.java
+++ b/src/main/java/gift/config/OperationSeparatorAspect.java
@@ -1,0 +1,27 @@
+package gift.config;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+public class OperationSeparatorAspect {
+
+    private static final String SEP = "────────────────────────────";
+
+    @Around("execution(* gift..*(..))")
+    public Object aroundServiceMethods(ProceedingJoinPoint pjp) throws Throwable {
+        Logger log = LoggerFactory.getLogger(pjp.getTarget().getClass());
+        String name = pjp.getSignature().toShortString();
+
+        log.info(SEP + " START [{}] " + SEP, name);
+        Object result = pjp.proceed();
+        log.info(SEP + " END   [{}] " + SEP, name);
+
+        return result;
+    }
+}

--- a/src/main/java/gift/controller/api/OptionController.java
+++ b/src/main/java/gift/controller/api/OptionController.java
@@ -63,12 +63,9 @@ public class OptionController {
         @PathVariable Long optionId,
         @RequestBody @Valid OptionRequestDto optionRequestDto
     ) {
-        Option saved = optionService.updateOption(productId, optionId, optionRequestDto);
+        Option updated = optionService.updateOption(productId, optionId, optionRequestDto);
 
-        URI location = URI.create(
-            "/api/products/%d/options/%d".formatted(productId, saved.getId()));
-        return ResponseEntity.created(location)
-            .body(OptionResponseDto.of(saved));
+        return ResponseEntity.ok(OptionResponseDto.of(updated));
     }
 
     @PatchMapping("/{optionId}/subtract")

--- a/src/main/java/gift/controller/api/OptionController.java
+++ b/src/main/java/gift/controller/api/OptionController.java
@@ -2,8 +2,12 @@ package gift.controller.api;
 
 import static org.springframework.data.domain.Sort.Direction.DESC;
 
+import gift.dto.api.OptionRequestDto;
 import gift.dto.api.OptionResponseDto;
+import gift.entity.Option;
 import gift.service.OptionService;
+import jakarta.validation.Valid;
+import java.net.URI;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
@@ -11,6 +15,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -31,5 +37,18 @@ public class OptionController {
     ) {
         Page<OptionResponseDto> options = optionService.getOptionList(productId, pageable);
         return new ResponseEntity<>(options, HttpStatus.OK);
+    }
+
+    @PostMapping
+    public ResponseEntity<OptionResponseDto> createOption(
+        @PathVariable Long productId,
+        @RequestBody @Valid OptionRequestDto optionRequestDto
+    ) {
+        Option saved = optionService.addOption(productId, optionRequestDto);
+
+        URI location = URI.create(
+            "/api/products/%d/options/%d".formatted(productId, saved.getId()));
+        return ResponseEntity.created(location)
+            .body(OptionResponseDto.of(saved));
     }
 }

--- a/src/main/java/gift/controller/api/OptionController.java
+++ b/src/main/java/gift/controller/api/OptionController.java
@@ -14,6 +14,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -75,6 +76,14 @@ public class OptionController {
         @RequestBody @Valid OptionSubtractRequestDto optionSubtractRequestDto
     ) {
         optionService.subtractQuantity(optionId, optionSubtractRequestDto.getQuantity());
+        return ResponseEntity.noContent().build();
+    }
+
+    @DeleteMapping("/{optionId}")
+    public ResponseEntity<Void> delete(
+        @PathVariable("optionId") Long optionId
+    ) {
+        optionService.deleteOption(optionId);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/gift/controller/api/OptionController.java
+++ b/src/main/java/gift/controller/api/OptionController.java
@@ -16,6 +16,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -45,6 +46,20 @@ public class OptionController {
         @RequestBody @Valid OptionRequestDto optionRequestDto
     ) {
         Option saved = optionService.addOption(productId, optionRequestDto);
+
+        URI location = URI.create(
+            "/api/products/%d/options/%d".formatted(productId, saved.getId()));
+        return ResponseEntity.created(location)
+            .body(OptionResponseDto.of(saved));
+    }
+
+    @PutMapping("/{optionId}")
+    public ResponseEntity<OptionResponseDto> updateOption(
+        @PathVariable Long productId,
+        @PathVariable Long optionId,
+        @RequestBody @Valid OptionRequestDto optionRequestDto
+    ) {
+        Option saved = optionService.updateOption(productId, optionId, optionRequestDto);
 
         URI location = URI.create(
             "/api/products/%d/options/%d".formatted(productId, saved.getId()));

--- a/src/main/java/gift/controller/api/OptionController.java
+++ b/src/main/java/gift/controller/api/OptionController.java
@@ -4,6 +4,7 @@ import static org.springframework.data.domain.Sort.Direction.DESC;
 
 import gift.dto.api.OptionRequestDto;
 import gift.dto.api.OptionResponseDto;
+import gift.dto.api.OptionSubtractRequestDto;
 import gift.entity.Option;
 import gift.service.OptionService;
 import jakarta.validation.Valid;
@@ -14,6 +15,7 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -65,5 +67,14 @@ public class OptionController {
             "/api/products/%d/options/%d".formatted(productId, saved.getId()));
         return ResponseEntity.created(location)
             .body(OptionResponseDto.of(saved));
+    }
+
+    @PatchMapping("/{optionId}/subtract")
+    public ResponseEntity<Void> subtractOptionQuantity(
+        @PathVariable("optionId") Long optionId,
+        @RequestBody @Valid OptionSubtractRequestDto optionSubtractRequestDto
+    ) {
+        optionService.subtractQuantity(optionId, optionSubtractRequestDto.getQuantity());
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/gift/controller/api/OptionController.java
+++ b/src/main/java/gift/controller/api/OptionController.java
@@ -1,0 +1,35 @@
+package gift.controller.api;
+
+import static org.springframework.data.domain.Sort.Direction.DESC;
+
+import gift.dto.api.OptionResponseDto;
+import gift.service.OptionService;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/products/{productId}/options")
+public class OptionController {
+
+    private final OptionService optionService;
+
+    public OptionController(OptionService optionService) {
+        this.optionService = optionService;
+    }
+
+    @GetMapping
+    public ResponseEntity<Page<OptionResponseDto>> getAllOptions(
+        @PathVariable Long productId,
+        @PageableDefault(size = 5, sort = "id", direction = DESC) Pageable pageable
+    ) {
+        Page<OptionResponseDto> options = optionService.getOptionList(productId, pageable);
+        return new ResponseEntity<>(options, HttpStatus.OK);
+    }
+}

--- a/src/main/java/gift/controller/api/OptionController.java
+++ b/src/main/java/gift/controller/api/OptionController.java
@@ -9,6 +9,7 @@ import gift.entity.Option;
 import gift.service.OptionService;
 import jakarta.validation.Valid;
 import java.net.URI;
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
@@ -35,11 +36,11 @@ public class OptionController {
     }
 
     @GetMapping
-    public ResponseEntity<Page<OptionResponseDto>> getAllOptions(
+    public ResponseEntity<List<OptionResponseDto>> getAllOptions(
         @PathVariable Long productId,
         @PageableDefault(size = 5, sort = "id", direction = DESC) Pageable pageable
     ) {
-        Page<OptionResponseDto> options = optionService.getOptionList(productId, pageable);
+        List<OptionResponseDto> options = optionService.getOptionList(productId, pageable).getContent();
         return new ResponseEntity<>(options, HttpStatus.OK);
     }
 

--- a/src/main/java/gift/controller/view/AdminProductViewController.java
+++ b/src/main/java/gift/controller/view/AdminProductViewController.java
@@ -2,9 +2,11 @@ package gift.controller.view;
 
 import static org.springframework.data.domain.Sort.Direction.DESC;
 
+import gift.dto.api.OptionResponseDto;
 import gift.dto.api.ProductUpdateRequestDto;
 import gift.dto.view.ProductViewRequestDto;
 import gift.entity.Product;
+import gift.service.OptionService;
 import gift.service.ProductService;
 import jakarta.validation.Valid;
 import java.util.NoSuchElementException;
@@ -26,9 +28,11 @@ import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 public class AdminProductViewController {
 
     private final ProductService productService;
+    private final OptionService optionService;
 
-    public AdminProductViewController(ProductService productService) {
+    public AdminProductViewController(ProductService productService, OptionService optionService) {
         this.productService = productService;
+        this.optionService = optionService;
     }
 
     // 상품 목록 화면
@@ -79,10 +83,14 @@ public class AdminProductViewController {
     @GetMapping("/{id}")
     public String viewProductDetail(@PathVariable Long id,
         Model model,
-        RedirectAttributes ra) {
+        RedirectAttributes ra,
+        @PageableDefault(size = 5, sort = "id", direction = DESC) Pageable pageable
+    ) {
         try {
             Product product = productService.getProductById(id);
+            Page<OptionResponseDto> options = optionService.getOptionList(id, pageable);
             model.addAttribute("product", product);
+            model.addAttribute("options",  options);
             return "products/admin/detail";
         } catch (NoSuchElementException e) {
             ra.addFlashAttribute("errorMsg", "상품을 찾을 수 없습니다.");

--- a/src/main/java/gift/controller/view/AdminProductViewController.java
+++ b/src/main/java/gift/controller/view/AdminProductViewController.java
@@ -83,14 +83,13 @@ public class AdminProductViewController {
     @GetMapping("/{id}")
     public String viewProductDetail(@PathVariable Long id,
         Model model,
-        RedirectAttributes ra,
-        @PageableDefault(size = 5, sort = "id", direction = DESC) Pageable pageable
+        RedirectAttributes ra
     ) {
         try {
             Product product = productService.getProductById(id);
-            Page<OptionResponseDto> options = optionService.getOptionList(id, pageable);
+            Page<OptionResponseDto> options = optionService.getOptionList(id, Pageable.unpaged());
             model.addAttribute("product", product);
-            model.addAttribute("options",  options);
+            model.addAttribute("options", options.getContent());
             return "products/admin/detail";
         } catch (NoSuchElementException e) {
             ra.addFlashAttribute("errorMsg", "상품을 찾을 수 없습니다.");

--- a/src/main/java/gift/controller/view/ProductViewController.java
+++ b/src/main/java/gift/controller/view/ProductViewController.java
@@ -2,7 +2,10 @@ package gift.controller.view;
 
 import static org.springframework.data.domain.Sort.Direction.DESC;
 
+import gift.dto.api.OptionResponseDto;
 import gift.entity.Product;
+import gift.repository.OptionRepository;
+import gift.service.OptionService;
 import gift.service.ProductService;
 import java.util.NoSuchElementException;
 import org.springframework.data.domain.Page;
@@ -20,9 +23,11 @@ import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 public class ProductViewController {
 
     private final ProductService productService;
+    private final OptionService optionService;
 
-    public ProductViewController(ProductService productService) {
+    public ProductViewController(ProductService productService, OptionService optionService) {
         this.productService = productService;
+        this.optionService = optionService;
     }
 
     // 상품 목록 화면
@@ -40,10 +45,14 @@ public class ProductViewController {
     @GetMapping("/{id}")
     public String viewProductDetail(@PathVariable Long id,
         Model model,
-        RedirectAttributes ra) {
+        RedirectAttributes ra,
+        @PageableDefault(size = 5, sort = "id", direction = DESC) Pageable pageable
+    ) {
         try {
             Product product = productService.getProductById(id);
+            Page<OptionResponseDto> options = optionService.getOptionList(id, pageable);
             model.addAttribute("product", product);
+            model.addAttribute("options",  options);
             return "products/user/detail";
         } catch (NoSuchElementException e) {
             ra.addFlashAttribute("errorMsg", "상품을 찾을 수 없습니다.");

--- a/src/main/java/gift/controller/view/ProductViewController.java
+++ b/src/main/java/gift/controller/view/ProductViewController.java
@@ -45,14 +45,13 @@ public class ProductViewController {
     @GetMapping("/{id}")
     public String viewProductDetail(@PathVariable Long id,
         Model model,
-        RedirectAttributes ra,
-        @PageableDefault(size = 5, sort = "id", direction = DESC) Pageable pageable
+        RedirectAttributes ra
     ) {
         try {
             Product product = productService.getProductById(id);
-            Page<OptionResponseDto> options = optionService.getOptionList(id, pageable);
+            Page<OptionResponseDto> options = optionService.getOptionList(id, Pageable.unpaged());
             model.addAttribute("product", product);
-            model.addAttribute("options",  options);
+            model.addAttribute("options", options.getContent());
             return "products/user/detail";
         } catch (NoSuchElementException e) {
             ra.addFlashAttribute("errorMsg", "상품을 찾을 수 없습니다.");

--- a/src/main/java/gift/dto/api/OptionRequestDto.java
+++ b/src/main/java/gift/dto/api/OptionRequestDto.java
@@ -1,0 +1,37 @@
+package gift.dto.api;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public class OptionRequestDto {
+
+    @NotBlank(message = "옵션 이름은 필수입니다.")
+    @Size(max = 50, message = "옵션 이름은 최대 50자까지 가능합니다.")
+    @Pattern(
+        regexp = "^[a-zA-Z0-9가-힣()\\[\\]+\\-&/_ ]*$",
+        message = "유효한 특수문자 ( '( )', '[ ]', '+', '-', '&', '/', '_' ) 가 아닙니다."
+    )
+    String name;
+
+    @NotNull(message = "수량은 필수입니다.")
+    @Min(value = 1, message = "수량은 1개 이상이어야 합니다.")
+    @Max(value = 100_000_000, message = "수량은 1억 개 미만이어야 합니다.")
+    Integer quantity;
+
+    public OptionRequestDto(String name, Integer quantity) {
+        this.name = name;
+        this.quantity = quantity;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public Integer getQuantity() {
+        return quantity;
+    }
+}

--- a/src/main/java/gift/dto/api/OptionResponseDto.java
+++ b/src/main/java/gift/dto/api/OptionResponseDto.java
@@ -22,8 +22,8 @@ public record OptionResponseDto (
     public static OptionResponseDto of(Option option) {
         return new OptionResponseDto(
             option.getId(),
-            option.getOptionName(),
-            option.getOptionQuantity()
+            option.getName(),
+            option.getQuantity()
         );
     }
 }

--- a/src/main/java/gift/dto/api/OptionResponseDto.java
+++ b/src/main/java/gift/dto/api/OptionResponseDto.java
@@ -1,0 +1,29 @@
+package gift.dto.api;
+
+import gift.entity.Option;
+
+public record OptionResponseDto (
+    Long id,
+    String name,
+    int quantity
+) {
+    public Long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public int getQuantity() {
+        return quantity;
+    }
+
+    public static OptionResponseDto of(Option option) {
+        return new OptionResponseDto(
+            option.getId(),
+            option.getOptionName(),
+            option.getOptionQuantity()
+        );
+    }
+}

--- a/src/main/java/gift/dto/api/OptionSubtractRequestDto.java
+++ b/src/main/java/gift/dto/api/OptionSubtractRequestDto.java
@@ -1,0 +1,21 @@
+package gift.dto.api;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+public class OptionSubtractRequestDto {
+
+    @NotNull(message = "수량은 필수입니다.")
+    @Min(value = 1, message = "수량은 1개 이상이어야 합니다.")
+    @Max(value = 100_000_000, message = "수량은 1억 개 미만이어야 합니다.")
+    Integer quantity;
+
+    public OptionSubtractRequestDto(Integer quantity) {
+        this.quantity = quantity;
+    }
+
+    public Integer getQuantity() {
+        return quantity;
+    }
+}

--- a/src/main/java/gift/entity/Option.java
+++ b/src/main/java/gift/entity/Option.java
@@ -1,0 +1,83 @@
+package gift.entity;
+
+import gift.exception.InsufficientStockException;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+@Entity
+@Table(name = "options")
+public class Option {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "option_name", nullable = false, length = 50, unique = true)
+    @NotBlank(message = "옵션 이름은 필수입니다.")
+    @Size(max = 50, message = "최대 50자까지 가능합니다.")
+    @Pattern(
+        regexp = "^[a-zA-Z0-9가-힣()\\[\\]+\\-&/_ ]*$",
+        message = "유효한 특수문자 ( '( )', '[ ]', '+', '-', '&', '/', '_' ) 가 아닙니다."
+    )
+    private String optionName;
+
+    @Column(name = "option_quantity", nullable = false)
+    @Min(value = 1, message = "수량은 1개 이상이어야 합니다.")
+    @Max(value = 100_000_000, message = "수량은 1억 개 미만이어야 합니다.")
+    private int optionQuantity;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "product_id")
+    private Product product;
+
+    protected Option() {}
+
+    public Option(Long id, Product product, String optionName, int optionQuantity) {
+        this.id = id;
+        this.product = product;
+        this.optionName = optionName;
+        this.optionQuantity = optionQuantity;
+    }
+
+    public Option(Product product, String name, int quantity) {
+        this(null, product, name, quantity);
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getOptionName() {
+        return optionName;
+    }
+
+    public int getOptionQuantity() {
+        return optionQuantity;
+    }
+
+    public Product getProduct() {
+        return product;
+    }
+
+    public void subtract(int optionQuantity) {
+        if (optionQuantity <= 0) {
+            throw new IllegalArgumentException("차감 수량은 1 이상이어야 합니다.");
+        }
+        if (optionQuantity > this.optionQuantity) {
+            throw new InsufficientStockException("재고가 부족합니다.");
+        }
+        this.optionQuantity -= optionQuantity;
+    }
+}

--- a/src/main/java/gift/entity/Option.java
+++ b/src/main/java/gift/entity/Option.java
@@ -26,19 +26,19 @@ public class Option {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "option_name", nullable = false, length = 50, unique = true)
+    @Column(nullable = false, length = 50, unique = true)
     @NotBlank(message = "옵션 이름은 필수입니다.")
     @Size(max = 50, message = "최대 50자까지 가능합니다.")
     @Pattern(
         regexp = "^[a-zA-Z0-9가-힣()\\[\\]+\\-&/_ ]*$",
         message = "유효한 특수문자 ( '( )', '[ ]', '+', '-', '&', '/', '_' ) 가 아닙니다."
     )
-    private String optionName;
+    private String name;
 
-    @Column(name = "option_quantity", nullable = false)
+    @Column(nullable = false)
     @Min(value = 1, message = "수량은 1개 이상이어야 합니다.")
     @Max(value = 100_000_000, message = "수량은 1억 개 미만이어야 합니다.")
-    private int optionQuantity;
+    private int quantity;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "product_id")
@@ -46,11 +46,11 @@ public class Option {
 
     protected Option() {}
 
-    public Option(Long id, Product product, String optionName, int optionQuantity) {
+    public Option(Long id, Product product, String name, int quantity) {
         this.id = id;
         this.product = product;
-        this.optionName = optionName;
-        this.optionQuantity = optionQuantity;
+        this.name = name;
+        this.quantity = quantity;
     }
 
     public Option(Product product, String name, int quantity) {
@@ -61,26 +61,26 @@ public class Option {
         return id;
     }
 
-    public String getOptionName() {
-        return optionName;
+    public String getName() {
+        return name;
     }
 
-    public int getOptionQuantity() {
-        return optionQuantity;
+    public int getQuantity() {
+        return quantity;
     }
 
     public Product getProduct() {
         return product;
     }
 
-    public void subtract(int optionQuantity) {
-        if (optionQuantity <= 0) {
+    public void subtract(int quantity) {
+        if (quantity <= 0) {
             throw new IllegalArgumentException("차감 수량은 1 이상이어야 합니다.");
         }
-        if (optionQuantity > this.optionQuantity) {
+        if (quantity > this.quantity) {
             throw new InsufficientStockException("재고가 부족합니다.");
         }
-        this.optionQuantity -= optionQuantity;
+        this.quantity -= quantity;
     }
 
     public boolean belongsTo(Long productId) {

--- a/src/main/java/gift/entity/Option.java
+++ b/src/main/java/gift/entity/Option.java
@@ -16,6 +16,8 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
+import java.util.Objects;
+
 @Entity
 @Table(name = "options")
 public class Option {
@@ -79,5 +81,9 @@ public class Option {
             throw new InsufficientStockException("재고가 부족합니다.");
         }
         this.optionQuantity -= optionQuantity;
+    }
+
+    public boolean belongsTo(Long productId) {
+        return Objects.equals(this.product.getId(), productId);
     }
 }

--- a/src/main/java/gift/entity/Product.java
+++ b/src/main/java/gift/entity/Product.java
@@ -25,6 +25,9 @@ public class Product {
     @OneToMany(mappedBy = "product", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<WishItem> wishItems = new ArrayList<>();
 
+    @OneToMany(mappedBy = "product", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Option> options = new ArrayList<>();
+
     protected Product() {
     }
 

--- a/src/main/java/gift/exception/GlobalExceptionHandler.java
+++ b/src/main/java/gift/exception/GlobalExceptionHandler.java
@@ -124,4 +124,11 @@ public class GlobalExceptionHandler {
         error.put("error", ex.getMessage());
         return new ResponseEntity<>(error, HttpStatus.NOT_FOUND);
     }
+
+    @ExceptionHandler(InsufficientStockException.class)
+    public ResponseEntity<Map<String, String>> handleInsufficientStock(InsufficientStockException e) {
+        Map<String, String> error = new HashMap<>();
+        error.put("error", e.getMessage());
+        return new ResponseEntity<>(error, HttpStatus.CONFLICT);
+    }
 }

--- a/src/main/java/gift/exception/GlobalExceptionHandler.java
+++ b/src/main/java/gift/exception/GlobalExceptionHandler.java
@@ -131,4 +131,11 @@ public class GlobalExceptionHandler {
         error.put("error", e.getMessage());
         return new ResponseEntity<>(error, HttpStatus.CONFLICT);
     }
+
+    @ExceptionHandler(OptionProductMismatchException.class)
+    public ResponseEntity<Map<String, String>> handleOptionProductMismatch(OptionProductMismatchException e) {
+        Map<String, String> error = new HashMap<>();
+        error.put("error", e.getMessage());
+        return new ResponseEntity<>(error, HttpStatus.CONFLICT);
+    }
 }

--- a/src/main/java/gift/exception/InsufficientStockException.java
+++ b/src/main/java/gift/exception/InsufficientStockException.java
@@ -1,0 +1,8 @@
+package gift.exception;
+
+public class InsufficientStockException extends RuntimeException {
+
+    public InsufficientStockException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/gift/exception/OptionProductMismatchException.java
+++ b/src/main/java/gift/exception/OptionProductMismatchException.java
@@ -1,0 +1,8 @@
+package gift.exception;
+
+public class OptionProductMismatchException extends RuntimeException {
+
+    public OptionProductMismatchException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/gift/repository/OptionRepository.java
+++ b/src/main/java/gift/repository/OptionRepository.java
@@ -1,6 +1,7 @@
 package gift.repository;
 
 import gift.entity.Option;
+import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
@@ -10,4 +11,7 @@ public interface OptionRepository extends JpaRepository<Option, Long> {
 
     @EntityGraph(attributePaths = "product")
     Page<Option> findAllByProductId(Long productId, Pageable pageable);
+
+    @EntityGraph(attributePaths = "product")
+    Optional<Option> findByProductIdAndOptionName(Long productId, String optionName);
 }

--- a/src/main/java/gift/repository/OptionRepository.java
+++ b/src/main/java/gift/repository/OptionRepository.java
@@ -1,0 +1,13 @@
+package gift.repository;
+
+import gift.entity.Option;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OptionRepository extends JpaRepository<Option, Long> {
+
+    @EntityGraph(attributePaths = "product")
+    Page<Option> findAllByProductId(Long productId, Pageable pageable);
+}

--- a/src/main/java/gift/repository/OptionRepository.java
+++ b/src/main/java/gift/repository/OptionRepository.java
@@ -13,5 +13,5 @@ public interface OptionRepository extends JpaRepository<Option, Long> {
     Page<Option> findAllByProductId(Long productId, Pageable pageable);
 
     @EntityGraph(attributePaths = "product")
-    Optional<Option> findByProductIdAndOptionName(Long productId, String optionName);
+    Optional<Option> findByProductIdAndName(Long productId, String optionName);
 }

--- a/src/main/java/gift/repository/ProductRepository.java
+++ b/src/main/java/gift/repository/ProductRepository.java
@@ -5,6 +5,5 @@ import gift.entity.Product;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-@Repository
 public interface ProductRepository extends JpaRepository<Product, Long> {
 }

--- a/src/main/java/gift/repository/WishRepository.java
+++ b/src/main/java/gift/repository/WishRepository.java
@@ -9,7 +9,6 @@ import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
-@Repository
 public interface WishRepository extends JpaRepository<WishItem, Long> {
 
     // 페이징용 메서드

--- a/src/main/java/gift/repository/WishRepository.java
+++ b/src/main/java/gift/repository/WishRepository.java
@@ -3,6 +3,7 @@ package gift.repository;
 import gift.entity.WishItem;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -12,9 +13,11 @@ import java.util.List;
 public interface WishRepository extends JpaRepository<WishItem, Long> {
 
     // 페이징용 메서드
+    @EntityGraph(attributePaths = "product")
     Page<WishItem> findAllByMemberId(Long memberId, Pageable pageable);
 
     // 리스트 조회용 메서드
+    @EntityGraph(attributePaths = "product")
     List<WishItem> findAllByMemberId(Long memberId);
 
     int deleteByMemberIdAndProductId(Long memberId, Long productId);

--- a/src/main/java/gift/service/OptionService.java
+++ b/src/main/java/gift/service/OptionService.java
@@ -1,0 +1,25 @@
+package gift.service;
+
+import gift.dto.api.OptionResponseDto;
+import gift.repository.OptionRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+public class OptionService {
+
+    private final OptionRepository optionRepository;
+
+    public OptionService(OptionRepository optionRepository) {
+        this.optionRepository = optionRepository;
+    }
+
+    public Page<OptionResponseDto> getOptionList(Long productId, Pageable pageable) {
+        return optionRepository
+            .findAllByProductId(productId, pageable)
+            .map(OptionResponseDto::of);
+    }
+}

--- a/src/main/java/gift/service/OptionService.java
+++ b/src/main/java/gift/service/OptionService.java
@@ -75,4 +75,13 @@ public class OptionService {
 
         return optionRepository.save(updatedOption);
     }
+
+    public void subtractQuantity(Long optionId, int qty) {
+        Option option = optionRepository.findById(optionId)
+            .orElseThrow(() -> new NoSuchElementException("옵션을 찾을 수 없습니다."));
+
+        // 엔티티 내부에서 검증 & 차감
+        option.subtract(qty);
+        // Dirty Checking → 트랜잭션 종료 시 UPDATE
+    }
 }

--- a/src/main/java/gift/service/OptionService.java
+++ b/src/main/java/gift/service/OptionService.java
@@ -1,7 +1,13 @@
 package gift.service;
 
+import gift.dto.api.OptionRequestDto;
 import gift.dto.api.OptionResponseDto;
+import gift.entity.Option;
+import gift.entity.Product;
 import gift.repository.OptionRepository;
+import gift.repository.ProductRepository;
+import java.util.NoSuchElementException;
+import org.springframework.dao.DuplicateKeyException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -12,14 +18,32 @@ import org.springframework.transaction.annotation.Transactional;
 public class OptionService {
 
     private final OptionRepository optionRepository;
+    private final ProductRepository productRepository;
 
-    public OptionService(OptionRepository optionRepository) {
+    public OptionService(OptionRepository optionRepository, ProductRepository productRepository) {
         this.optionRepository = optionRepository;
+        this.productRepository = productRepository;
     }
 
     public Page<OptionResponseDto> getOptionList(Long productId, Pageable pageable) {
         return optionRepository
             .findAllByProductId(productId, pageable)
             .map(OptionResponseDto::of);
+    }
+
+    public Option addOption(Long productId, OptionRequestDto optionRequestDto) {
+        Product product = productRepository.findById(productId)
+            .orElseThrow(() -> new NoSuchElementException("상품을 찾을 수 없습니다."));
+
+        optionRepository.findByProductIdAndOptionName(productId, optionRequestDto.getName())
+            .ifPresent(option -> {
+                throw new DuplicateKeyException("이미 존재하는 옵션입니다.");
+            });
+
+        return optionRepository.save(new Option(
+            product,
+            optionRequestDto.getName(),
+            optionRequestDto.getQuantity()
+        ));
     }
 }

--- a/src/main/java/gift/service/OptionService.java
+++ b/src/main/java/gift/service/OptionService.java
@@ -26,6 +26,7 @@ public class OptionService {
         this.productRepository = productRepository;
     }
 
+    @Transactional(readOnly = true)
     public Page<OptionResponseDto> getOptionList(Long productId, Pageable pageable) {
         return optionRepository
             .findAllByProductId(productId, pageable)

--- a/src/main/java/gift/service/OptionService.java
+++ b/src/main/java/gift/service/OptionService.java
@@ -54,9 +54,11 @@ public class OptionService {
             .orElseThrow(() -> new NoSuchElementException("옵션을 찾을 수 없습니다."));
 
         if (!option.belongsTo(productId)) {
+            Product otherProduct = productRepository.findById(productId)
+                .orElseThrow(() -> new NoSuchElementException("상품을 찾을 수 없습니다."));
+
             throw new OptionProductMismatchException(
-                    option.getName() + " 옵션은 " + option.getProduct().getName() + " 상품에 속하지 않습니다."
-            );
+                option.getName() + " 옵션은 " + otherProduct.getName() + " 상품에 속하지 않습니다.");
         }
 
         optionRepository.findByProductIdAndName(option.getProduct().getId(), optionRequestDto.getName())

--- a/src/main/java/gift/service/OptionService.java
+++ b/src/main/java/gift/service/OptionService.java
@@ -49,15 +49,12 @@ public class OptionService {
     }
 
     public Option updateOption(Long productId, Long optionId, OptionRequestDto optionRequestDto) {
-        Product product = productRepository.findById(productId)
-            .orElseThrow(() -> new NoSuchElementException("상품을 찾을 수 없습니다."));
-
         Option option = optionRepository.findById(optionId)
             .orElseThrow(() -> new NoSuchElementException("옵션을 찾을 수 없습니다."));
 
-        if (option.getProduct().getId() != product.getId()) {
+        if (!option.belongsTo(productId)) {
             throw new OptionProductMismatchException(
-                option.getOptionName() + " 옵션은 " + product.getName() + " 상품에 속하지 않습니다."
+                    option.getOptionName() + " 옵션은 " + option.getProduct().getName() + " 상품에 속하지 않습니다."
             );
         }
 

--- a/src/main/java/gift/service/OptionService.java
+++ b/src/main/java/gift/service/OptionService.java
@@ -37,7 +37,7 @@ public class OptionService {
         Product product = productRepository.findById(productId)
             .orElseThrow(() -> new NoSuchElementException("상품을 찾을 수 없습니다."));
 
-        optionRepository.findByProductIdAndOptionName(productId, optionRequestDto.getName())
+        optionRepository.findByProductIdAndName(productId, optionRequestDto.getName())
             .ifPresent(option -> {
                 throw new DuplicateKeyException("이미 존재하는 옵션입니다.");
             });
@@ -55,11 +55,11 @@ public class OptionService {
 
         if (!option.belongsTo(productId)) {
             throw new OptionProductMismatchException(
-                    option.getOptionName() + " 옵션은 " + option.getProduct().getName() + " 상품에 속하지 않습니다."
+                    option.getName() + " 옵션은 " + option.getProduct().getName() + " 상품에 속하지 않습니다."
             );
         }
 
-        optionRepository.findByProductIdAndOptionName(option.getProduct().getId(), optionRequestDto.getName())
+        optionRepository.findByProductIdAndName(option.getProduct().getId(), optionRequestDto.getName())
             .ifPresent(o -> {
                 throw new DuplicateKeyException("이미 존재하는 옵션입니다.");
             });

--- a/src/main/java/gift/service/OptionService.java
+++ b/src/main/java/gift/service/OptionService.java
@@ -84,4 +84,11 @@ public class OptionService {
         option.subtract(qty);
         // Dirty Checking → 트랜잭션 종료 시 UPDATE
     }
+
+    public void deleteOption(Long optionId) {
+        optionRepository.findById(optionId)
+            .orElseThrow(() -> new NoSuchElementException("옵션을 찾을 수 없습니다."));
+
+        optionRepository.deleteById(optionId);
+    }
 }

--- a/src/main/java/gift/service/OptionService.java
+++ b/src/main/java/gift/service/OptionService.java
@@ -4,6 +4,7 @@ import gift.dto.api.OptionRequestDto;
 import gift.dto.api.OptionResponseDto;
 import gift.entity.Option;
 import gift.entity.Product;
+import gift.exception.OptionProductMismatchException;
 import gift.repository.OptionRepository;
 import gift.repository.ProductRepository;
 import java.util.NoSuchElementException;
@@ -45,5 +46,33 @@ public class OptionService {
             optionRequestDto.getName(),
             optionRequestDto.getQuantity()
         ));
+    }
+
+    public Option updateOption(Long productId, Long optionId, OptionRequestDto optionRequestDto) {
+        Product product = productRepository.findById(productId)
+            .orElseThrow(() -> new NoSuchElementException("상품을 찾을 수 없습니다."));
+
+        Option option = optionRepository.findById(optionId)
+            .orElseThrow(() -> new NoSuchElementException("옵션을 찾을 수 없습니다."));
+
+        if (option.getProduct().getId() != product.getId()) {
+            throw new OptionProductMismatchException(
+                option.getOptionName() + " 옵션은 " + product.getName() + " 상품에 속하지 않습니다."
+            );
+        }
+
+        optionRepository.findByProductIdAndOptionName(option.getProduct().getId(), optionRequestDto.getName())
+            .ifPresent(o -> {
+                throw new DuplicateKeyException("이미 존재하는 옵션입니다.");
+            });
+
+        Option updatedOption = new Option(
+            optionId,
+            option.getProduct(),
+            optionRequestDto.getName(),
+            optionRequestDto.getQuantity()
+        );
+
+        return optionRepository.save(updatedOption);
     }
 }

--- a/src/main/java/gift/service/WishService.java
+++ b/src/main/java/gift/service/WishService.java
@@ -29,6 +29,7 @@ public class WishService {
         this.productRepository = productRepository;
     }
 
+    @Transactional(readOnly = true)
     public Page<WishResponseDto> getWishListForMember(Member member, Pageable pageable) {
         validateMember(member);
         return wishRepository

--- a/src/main/resources/import.sql
+++ b/src/main/resources/import.sql
@@ -10,3 +10,7 @@ INSERT INTO approved_products (name) VALUES ('카카오 프렌즈 인형');
 
 INSERT INTO members (email, password, is_admin) VALUES ('5seonjae@gmail.com', '5seonjae', true);
 INSERT INTO members (email, password, is_admin) VALUES ('6seonjae@gmail.com', '6seonjae', false);
+
+INSERT INTO options (product_id, option_name, option_quantity) VALUES (1, '다크 초콜릿', 5);
+INSERT INTO options (product_id, option_name, option_quantity) VALUES (1, '화이트 초콜릿', 4);
+INSERT INTO options (product_id, option_name, option_quantity) VALUES (1, '아몬드 초콜릿', 3);

--- a/src/main/resources/import.sql
+++ b/src/main/resources/import.sql
@@ -14,3 +14,6 @@ INSERT INTO members (email, password, is_admin) VALUES ('6seonjae@gmail.com', '6
 INSERT INTO options (product_id, option_name, option_quantity) VALUES (1, '다크 초콜릿', 5);
 INSERT INTO options (product_id, option_name, option_quantity) VALUES (1, '화이트 초콜릿', 4);
 INSERT INTO options (product_id, option_name, option_quantity) VALUES (1, '아몬드 초콜릿', 3);
+INSERT INTO options (product_id, option_name, option_quantity) VALUES (1, '두바이 초콜릿', 5);
+INSERT INTO options (product_id, option_name, option_quantity) VALUES (1, '스위스 초콜릿', 4);
+INSERT INTO options (product_id, option_name, option_quantity) VALUES (1, '누텔라 초콜릿', 3);

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -30,4 +30,14 @@ CREATE TABLE wish_items
     CONSTRAINT uk_member_product UNIQUE (member_id, product_id),
     CONSTRAINT fk_wish_member FOREIGN KEY (member_id) REFERENCES members(id),
     CONSTRAINT fk_wish_product FOREIGN KEY (product_id) REFERENCES products(id)
-)
+);
+
+CREATE TABLE options
+(
+    id BIGINT PRIMARY KEY AUTO_INCREMENT,
+    product_id BIGINT NOT NULL,
+    name VARCHAR(50) NOT NULL UNIQUE,
+    quantity INT NOT NULL,
+    CONSTRAINT uk_product UNIQUE (product_id),
+    CONSTRAINT fk_option_product FOREIGN KEY (product_id) REFERENCES products(id)
+);

--- a/src/main/resources/templates/products/admin/detail.html
+++ b/src/main/resources/templates/products/admin/detail.html
@@ -19,6 +19,18 @@
     </p>
   </div>
 
+  <h3>옵션 선택</h3>
+  <ul>
+    <li th:each="opt : ${options}">
+      <label>
+        <input type="radio" name="optionId" th:value="${opt.id}"
+               th:disabled="${opt.quantity == 0}" />
+        <span th:text="${opt.name}">6개</span>
+        <span th:text="${#numbers.formatInteger(opt.quantity, 0)} + '개 재고'"></span>
+      </label>
+    </li>
+  </ul>
+
   <div class="button-group">
     <a th:href="@{/admin/products}" class="button">← 목록으로</a>
     <a th:href="@{'/admin/products/' + ${product.id} + '/edit'}" class="button edit">✏️ 수정</a>

--- a/src/main/resources/templates/products/user/detail.html
+++ b/src/main/resources/templates/products/user/detail.html
@@ -19,6 +19,18 @@
     </p>
   </div>
 
+  <h3>옵션 선택</h3>
+  <ul>
+    <li th:each="opt : ${options}">
+      <label>
+        <input type="radio" name="optionId" th:value="${opt.id}"
+               th:disabled="${opt.quantity == 0}" />
+        <span th:text="${opt.name}">6개</span>
+        <span th:text="${#numbers.formatInteger(opt.quantity, 0)} + '개 재고'"></span>
+      </label>
+    </li>
+  </ul>
+
   <div class="button-group">
     <a th:href="@{/products}" class="button">← 목록으로</a>
   </div>

--- a/src/test/java/gift/OptionControllerTest.java
+++ b/src/test/java/gift/OptionControllerTest.java
@@ -237,7 +237,7 @@ public class OptionControllerTest {
         }
 
         @Test
-        @DisplayName("[API] 옵션 수정 성공 - 이름·수량 수정 → 201 Created + Location + Body")
+        @DisplayName("[API] 옵션 수정 성공 - 이름·수량 수정 → 200 Ok + Body")
         void update_success() throws Exception {
             var dto = new OptionRequestDto("아몬드 초콜릿", 7);
 
@@ -248,11 +248,7 @@ public class OptionControllerTest {
                 )
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsBytes(dto)))
-                .andExpect(status().isCreated())
-                .andExpect(header().string(
-                    "Location",
-                    "/api/products/"+product.getId()+"/options/"+option.getId()
-                ))
+                .andExpect(status().isOk())
                 .andExpect(jsonPath("$.name").value("아몬드 초콜릿"))
                 .andExpect(jsonPath("$.quantity").value(7));
 

--- a/src/test/java/gift/OptionControllerTest.java
+++ b/src/test/java/gift/OptionControllerTest.java
@@ -1,0 +1,58 @@
+package gift;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import gift.entity.Option;
+import gift.entity.Product;
+import gift.repository.OptionRepository;
+import gift.repository.ProductRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+public class OptionControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private OptionRepository optionRepository;
+
+    @Autowired
+    private ProductRepository productRepository;
+
+    Product product;
+
+    @BeforeEach
+    void setUp() {
+        productRepository.deleteAll();
+        optionRepository.deleteAll();
+
+        product = productRepository.save(new Product("초콜릿", 1000, "http://choco/png"));
+    }
+
+    @Test
+    @DisplayName("GET /api/products/{id}/options : 옵션 페이지 반환")
+    void listOptions() throws Exception {
+        optionRepository.save(new Option(product, "다크 초콜릿", 10));
+        optionRepository.save(new Option(product, "화이트 초콜릿", 8));
+
+        mockMvc.perform(get("/api/products/{productId}/options", product.getId()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.content.length()").value(2))
+            .andExpect(jsonPath("$.content[0].name").value("화이트 초콜릿"))
+            .andExpect(jsonPath("$.content[0].quantity").value(8))
+            .andExpect(jsonPath("$.content[1].name").value("다크 초콜릿"))
+            .andExpect(jsonPath("$.content[1].quantity").value(10));
+    }
+}

--- a/src/test/java/gift/OptionControllerTest.java
+++ b/src/test/java/gift/OptionControllerTest.java
@@ -1,19 +1,26 @@
 package gift;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import gift.dto.api.OptionRequestDto;
 import gift.entity.Option;
 import gift.entity.Product;
 import gift.repository.OptionRepository;
 import gift.repository.ProductRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -24,6 +31,9 @@ public class OptionControllerTest {
 
     @Autowired
     private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
 
     @Autowired
     private OptionRepository optionRepository;
@@ -55,4 +65,159 @@ public class OptionControllerTest {
             .andExpect(jsonPath("$.content[1].name").value("다크 초콜릿"))
             .andExpect(jsonPath("$.content[1].quantity").value(10));
     }
+
+    @Nested
+    class CreateOption {
+
+        @Test
+        @DisplayName("[API] 옵션 생성 성공 201 Created + Location")
+        void createOption_success() throws Exception {
+            var dto = new OptionRequestDto("다크 초콜릿", 10);
+            mockMvc.perform(post("/api/products/{productId}/options", product.getId())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(dto)))
+                .andExpect(status().isCreated())
+                .andExpect(header().string(
+                    "Location",
+                    org.hamcrest.Matchers.matchesRegex(
+                        "/api/products/" + product.getId() + "/options/\\d+")
+                ))
+                .andExpect(jsonPath("$.id").isNumber())
+                .andExpect(jsonPath("$.name").value(dto.getName()))
+                .andExpect(jsonPath("$.quantity").value(dto.getQuantity()));
+
+            assertThat(optionRepository.findByProductIdAndOptionName(product.getId(),
+                "다크 초콜릿")).isPresent();
+        }
+
+        @Test
+        @DisplayName("[Api] 옵션 생성 실패 - 상품 이름 중복 409 Conflict")
+        void createOption_duplicate() throws Exception {
+            optionRepository.save(new Option(product, "다크 초콜릿", 10));
+            var dto = new OptionRequestDto("다크 초콜릿", 5);
+
+            mockMvc.perform(post("/api/products/{productId}/options", product.getId())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(dto)))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.error").value("이미 존재하는 옵션입니다."));
+        }
+
+        /* ───── 유효성 시나리오 ───── */
+        @Test
+        @DisplayName("[API] 옵션 생성 실패 - 빈 옵션명 400 Bad Request")
+        void create_blankName() throws Exception {
+            var dto = new OptionRequestDto("", 10);
+
+            mockMvc.perform(post("/api/products/{productId}/options", product.getId())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(dto)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.name").value("옵션 이름은 필수입니다."));
+        }
+
+        @Test
+        @DisplayName("[API] 옵션 생성 실패 - 옵션명 50자 초과 400 Bad Request")
+        void create_nameTooLong() throws Exception {
+            var dto = new OptionRequestDto(
+                "123456789_123456789_123456789_123456789_123456789_1",
+                10);
+
+            mockMvc.perform(post("/api/products/{productId}/options", product.getId())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(dto)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.name").value("옵션 이름은 최대 50자까지 가능합니다."));
+        }
+
+        @Test
+        @DisplayName("[API] 옵션 생성 실패 - 옵션명에 허용되지 않은 특수문자 사용 400 Bad Request")
+        void create_invalidChar() throws Exception {
+            var dto = new OptionRequestDto(
+                "다크 초콜릿!",
+                10);
+
+            mockMvc.perform(post("/api/products/{productId}/options", product.getId())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(dto)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.name")
+                    .value("유효한 특수문자 ( '( )', '[ ]', '+', '-', '&', '/', '_' ) 가 아닙니다."));
+        }
+
+        @Test
+        @DisplayName("[API] 옵션 생성 실패 - 수량 < 1 400 Bad Request")
+        void create_quantityZero() throws Exception {
+            var dto = new OptionRequestDto(
+                "다크 초콜릿",
+                -10);
+
+            mockMvc.perform(post("/api/products/{productId}/options", product.getId())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(dto)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.quantity")
+                    .value("수량은 1개 이상이어야 합니다."));
+        }
+
+        @Test
+        @DisplayName("[API] 옵션 생성 실패 - 수량 > 1억 400 Bad Request")
+        void create_quantityTooLarge() throws Exception {
+            var dto = new OptionRequestDto(
+                "다크 초콜릿",
+                100_000_001);
+
+            mockMvc.perform(post("/api/products/{productId}/options", product.getId())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(dto)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.quantity")
+                    .value("수량은 1억 개 미만이어야 합니다."));
+        }
+
+        @Test
+        @DisplayName("[API] 옵션 생성 실패 - 값 누락 400 Bad Request")
+        void create_missingName() throws Exception {
+            String badJson = "{"
+                + "\"name\": ,"
+                + "\"quantity\": 10"
+                + "}";
+
+            mockMvc.perform(post("/api/products/{productId}/options", product.getId())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(badJson))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error")
+                    .value("요청 JSON 형식이 잘못되었습니다."));
+        }
+
+        /* ───── JSON 필드 누락 ───── */
+        @Test @DisplayName("[API] 옵션 생성 실패 - 수량에 문자를 넣는 경우 400 Bad Request")
+        void create_missingQuantity() throws Exception {
+            String badJson = "{"
+                + "\"name\": \"다크 초콜릿\","
+                + "\"quantity\": \"과자\""
+                + "}";
+
+            mockMvc.perform(post("/api/products/{productId}/options", product.getId())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(badJson))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error")
+                    .value("'quantity' 필드는 Integer 형식이어야 합니다."));
+        }
+
+        /* ───── 리소스 시나리오 ───── */
+        @Test @DisplayName("[API] 옵션 생성 실패 - 상품 없음 404 Not Found")
+        void create_nonExistingProduct() throws Exception {
+            var dto = new OptionRequestDto("다크 초콜릿", 10);
+
+            mockMvc.perform(post("/api/products/{productId}/options", 9999L)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsBytes(dto)))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.error").value("상품을 찾을 수 없습니다."));
+        }
+    }
+
 }

--- a/src/test/java/gift/OptionControllerTest.java
+++ b/src/test/java/gift/OptionControllerTest.java
@@ -5,6 +5,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -569,6 +570,36 @@ public class OptionControllerTest {
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.error")
                     .value("'quantity' 필드는 Integer 형식이어야 합니다."));
+        }
+    }
+
+    @Nested
+    class DeleteOption {
+        @Test
+        @DisplayName("[API] 옵션 제거 성공 - 204 No Content + removed")
+        void delete_success() throws Exception {
+            Option option = optionRepository.save(new Option(product, "다크 초콜릿", 10));
+
+            mockMvc.perform(delete(
+                    "/api/products/{productId}/options/{optionId}",
+                    product.getId(),
+                    option.getId())
+                )
+                .andExpect(status().isNoContent());
+
+            assertThat(optionRepository.findById(option.getId())).isNotPresent();
+        }
+
+        @Test
+        @DisplayName("[API] 옵션 제거 실패 - 존재하지 않는 옵션 404 Not Found")
+        void delete_notFound() throws Exception {
+            mockMvc.perform(delete(
+                    "/api/products/{productId}/options/{optionId}",
+                    product.getId(),
+                    999L)
+                )
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.error").value("옵션을 찾을 수 없습니다."));
         }
     }
 }

--- a/src/test/java/gift/OptionControllerTest.java
+++ b/src/test/java/gift/OptionControllerTest.java
@@ -56,18 +56,18 @@ public class OptionControllerTest {
     }
 
     @Test
-    @DisplayName("GET /api/products/{id}/options : 옵션 페이지 반환")
+    @DisplayName("GET /api/products/{id}/options : 옵션 배열 반환")
     void listOptions() throws Exception {
         optionRepository.save(new Option(product, "다크 초콜릿", 10));
         optionRepository.save(new Option(product, "화이트 초콜릿", 8));
 
         mockMvc.perform(get("/api/products/{productId}/options", product.getId()))
             .andExpect(status().isOk())
-            .andExpect(jsonPath("$.content.length()").value(2))
-            .andExpect(jsonPath("$.content[0].name").value("화이트 초콜릿"))
-            .andExpect(jsonPath("$.content[0].quantity").value(8))
-            .andExpect(jsonPath("$.content[1].name").value("다크 초콜릿"))
-            .andExpect(jsonPath("$.content[1].quantity").value(10));
+            .andExpect(jsonPath("$.length()").value(2))
+            .andExpect(jsonPath("$[0].name").value("화이트 초콜릿"))
+            .andExpect(jsonPath("$[0].quantity").value(8))
+            .andExpect(jsonPath("$[1].name").value("다크 초콜릿"))
+            .andExpect(jsonPath("$[1].quantity").value(10));
     }
 
     @Nested

--- a/src/test/java/gift/OptionControllerTest.java
+++ b/src/test/java/gift/OptionControllerTest.java
@@ -90,7 +90,7 @@ public class OptionControllerTest {
                 .andExpect(jsonPath("$.name").value(dto.getName()))
                 .andExpect(jsonPath("$.quantity").value(dto.getQuantity()));
 
-            assertThat(optionRepository.findByProductIdAndOptionName(product.getId(),
+            assertThat(optionRepository.findByProductIdAndName(product.getId(),
                 "다크 초콜릿")).isPresent();
         }
 
@@ -253,8 +253,8 @@ public class OptionControllerTest {
                 .andExpect(jsonPath("$.quantity").value(7));
 
             Option changed = optionRepository.findById(option.getId()).orElseThrow();
-            assertThat(changed.getOptionName()).isEqualTo("아몬드 초콜릿");
-            assertThat(changed.getOptionQuantity()).isEqualTo(7);
+            assertThat(changed.getName()).isEqualTo("아몬드 초콜릿");
+            assertThat(changed.getQuantity()).isEqualTo(7);
         }
 
         @Test
@@ -460,7 +460,7 @@ public class OptionControllerTest {
                     .content(objectMapper.writeValueAsBytes(dto)))
                 .andExpect(status().isConflict())
                 .andExpect(jsonPath("$.error")
-                    .value(otherOption.getOptionName() + " 옵션은 " + product.getName() + " 상품에 속하지 않습니다."));
+                    .value(otherOption.getName() + " 옵션은 " + product.getName() + " 상품에 속하지 않습니다."));
         }
     }
 
@@ -490,7 +490,7 @@ public class OptionControllerTest {
             assertThat(
                 optionRepository
                     .findById(option.getId())
-                    .orElseThrow().getOptionQuantity()).isEqualTo(7);
+                    .orElseThrow().getQuantity()).isEqualTo(7);
         }
 
         @Test

--- a/src/test/java/gift/OptionControllerTest.java
+++ b/src/test/java/gift/OptionControllerTest.java
@@ -2,6 +2,7 @@ package gift;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
@@ -10,6 +11,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import gift.dto.api.OptionRequestDto;
+import gift.dto.api.OptionSubtractRequestDto;
 import gift.entity.Option;
 import gift.entity.Product;
 import gift.repository.OptionRepository;
@@ -462,6 +464,111 @@ public class OptionControllerTest {
                 .andExpect(status().isConflict())
                 .andExpect(jsonPath("$.error")
                     .value(otherOption.getOptionName() + " 옵션은 " + product.getName() + " 상품에 속하지 않습니다."));
+        }
+    }
+
+    @Nested
+    class SubtractQuantity {
+        Option option;
+
+        @BeforeEach
+        void initOption() {
+            option = optionRepository.save(new Option(product, "다크 초콜릿", 10));
+        }
+
+        @Test
+        @DisplayName("[API] 옵션 수량 감소 성공 - 204 No Content + 수량 감소")
+        void subtract_success() throws Exception {
+            var dto = new OptionSubtractRequestDto(3);
+
+            mockMvc.perform(patch(
+                    "/api/products/{productId}/options/{optionId}/subtract",
+                    product.getId(),
+                    option.getId()
+                )
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsBytes(dto)))
+                .andExpect(status().isNoContent());
+
+            assertThat(
+                optionRepository
+                    .findById(option.getId())
+                    .orElseThrow().getOptionQuantity()).isEqualTo(7);
+        }
+
+        @Test
+        @DisplayName("[API] 옵션 수량 감소 실패 - 수량 부족 409 Conflict")
+        void subtract_insufficient() throws Exception {
+            var dto = new OptionRequestDto("다크 초콜릿", 999);
+
+            mockMvc.perform(patch(
+                    "/api/products/{productId}/options/{optionId}/subtract",
+                    product.getId(),
+                    option.getId()
+                )
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsBytes(dto)))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.error")
+                    .value("재고가 부족합니다."));
+        }
+
+        @Test
+        @DisplayName("[API] 옵션 수량 감소 실패 - 수량 < 1 400 Bad Request")
+        void subtract_quantityZero() throws Exception {
+            var dto = new OptionRequestDto(
+                "다크 초콜릿",
+                -10
+            );
+
+            mockMvc.perform(patch(
+                    "/api/products/{productId}/options/{optionId}/subtract",
+                    product.getId(),
+                    option.getId()
+                )
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsBytes(dto)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.quantity")
+                    .value("수량은 1개 이상이어야 합니다."));
+        }
+
+        @Test
+        @DisplayName("[API] 옵션 수량 감소 실패 - 수량 > 1억 400 Bad Request")
+        void subtract_quantityTooLarge() throws Exception {
+            var dto = new OptionRequestDto(
+                "다크 초콜릿",
+                100_000_001
+            );
+
+            mockMvc.perform(patch(
+                    "/api/products/{productId}/options/{optionId}/subtract",
+                    product.getId(),
+                    option.getId()
+                )
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsBytes(dto)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.quantity")
+                    .value("수량은 1억 개 미만이어야 합니다."));
+        }
+
+        @Test @DisplayName("[API] 옵션 수량 감소 실패 - 수량에 문자를 넣는 경우 400 Bad Request")
+        void subtract_missingQuantity() throws Exception {
+            String badJson = "{"
+                + "\"quantity\": \"과자\","
+                + "}";
+
+            mockMvc.perform(patch(
+                    "/api/products/{productId}/options/{optionId}/subtract",
+                    product.getId(),
+                    option.getId()
+                )
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(badJson))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error")
+                    .value("'quantity' 필드는 Integer 형식이어야 합니다."));
         }
     }
 }

--- a/src/test/java/gift/OptionControllerTest.java
+++ b/src/test/java/gift/OptionControllerTest.java
@@ -3,6 +3,7 @@ package gift;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -220,4 +221,247 @@ public class OptionControllerTest {
         }
     }
 
+    @Nested
+    class UpdateOption {
+
+        Option option;
+
+        @BeforeEach
+        void init() {
+            option = optionRepository.save(new Option(product, "다크 초콜릿", 10));
+            // duplicate 용
+            optionRepository.save(new Option(product, "화이트 초콜릿", 5));
+        }
+
+        @Test
+        @DisplayName("[API] 옵션 수정 성공 - 이름·수량 수정 → 201 Created + Location + Body")
+        void update_success() throws Exception {
+            var dto = new OptionRequestDto("아몬드 초콜릿", 7);
+
+            mockMvc.perform(put(
+                    "/api/products/{productId}/options/{optionId}",
+                    product.getId(),
+                    option.getId()
+                )
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsBytes(dto)))
+                .andExpect(status().isCreated())
+                .andExpect(header().string(
+                    "Location",
+                    "/api/products/"+product.getId()+"/options/"+option.getId()
+                ))
+                .andExpect(jsonPath("$.name").value("아몬드 초콜릿"))
+                .andExpect(jsonPath("$.quantity").value(7));
+
+            Option changed = optionRepository.findById(option.getId()).orElseThrow();
+            assertThat(changed.getOptionName()).isEqualTo("아몬드 초콜릿");
+            assertThat(changed.getOptionQuantity()).isEqualTo(7);
+        }
+
+        @Test
+        @DisplayName("[API] 옵션 수정 실패 - 옵션명 중복 → 409 Conflict")
+        void update_duplicateName() throws Exception {
+            var dto = new OptionRequestDto("화이트 초콜릿", 7);
+
+            mockMvc.perform(put(
+                    "/api/products/{productId}/options/{optionId}",
+                    product.getId(),
+                    option.getId()
+                )
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsBytes(dto)))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.error")
+                    .value("이미 존재하는 옵션입니다."));
+        }
+
+        /* ───── 유효성 시나리오 ───── */
+        @Test
+        @DisplayName("[API] 옵션 수정 실패 - 빈 옵션명 400 Bad Request")
+        void update_blankName() throws Exception {
+            var dto = new OptionRequestDto("", 7);
+
+            mockMvc.perform(put(
+                    "/api/products/{productId}/options/{optionId}",
+                    product.getId(),
+                    option.getId()
+                )
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsBytes(dto)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.name")
+                    .value("옵션 이름은 필수입니다."));
+        }
+
+        @Test
+        @DisplayName("[API] 옵션 수정 실패 - 옵션명 50자 초과 400 Bad Request")
+        void update_nameTooLong() throws Exception {
+            var dto = new OptionRequestDto(
+                "123456789_123456789_123456789_123456789_123456789_1",
+                7
+            );
+
+            mockMvc.perform(put(
+                    "/api/products/{productId}/options/{optionId}",
+                    product.getId(),
+                    option.getId()
+                )
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsBytes(dto)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.name")
+                    .value("옵션 이름은 최대 50자까지 가능합니다."));
+        }
+
+        @Test
+        @DisplayName("[API] 옵션 수정 실패 - 옵션명에 허용되지 않은 특수문자 사용 400 Bad Request")
+        void update_invalidChar() throws Exception {
+            var dto = new OptionRequestDto(
+                "다크 초콜릿!",
+                10
+            );
+
+            mockMvc.perform(put(
+                    "/api/products/{productId}/options/{optionId}",
+                    product.getId(),
+                    option.getId()
+                )
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsBytes(dto)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.name")
+                    .value("유효한 특수문자 ( '( )', '[ ]', '+', '-', '&', '/', '_' ) 가 아닙니다."));
+        }
+
+        @Test
+        @DisplayName("[API] 옵션 수정 실패 - 수량 < 1 400 Bad Request")
+        void update_quantityZero() throws Exception {
+            var dto = new OptionRequestDto(
+                "다크 초콜릿",
+                -10
+            );
+
+            mockMvc.perform(put(
+                    "/api/products/{productId}/options/{optionId}",
+                    product.getId(),
+                    option.getId()
+                )
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsBytes(dto)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.quantity")
+                    .value("수량은 1개 이상이어야 합니다."));
+        }
+
+        @Test
+        @DisplayName("[API] 옵션 수정 실패 - 수량 > 1억 400 Bad Request")
+        void update_quantityTooLarge() throws Exception {
+            var dto = new OptionRequestDto(
+                "다크 초콜릿",
+                100_000_001
+            );
+
+            mockMvc.perform(put(
+                    "/api/products/{productId}/options/{optionId}",
+                    product.getId(),
+                    option.getId()
+                )
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsBytes(dto)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.quantity")
+                    .value("수량은 1억 개 미만이어야 합니다."));
+        }
+
+        /* ───── JSON 필드 누락 ───── */
+        @Test @DisplayName("[API] 옵션 수정 실패 - 값 누락 400 Bad Request")
+        void update_missingName() throws Exception {
+            String badJson = "{"
+                + "\"name\": ,"
+                + "\"quantity\": 10"
+                + "}";
+
+            mockMvc.perform(put(
+                    "/api/products/{productId}/options/{optionId}",
+                    product.getId(),
+                    option.getId()
+                )
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(badJson))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error")
+                    .value("요청 JSON 형식이 잘못되었습니다."));
+        }
+
+        @Test @DisplayName("[API] 옵션 수정 실패 - 수량에 문자를 넣는 경우 400 Bad Request")
+        void update_missingQuantity() throws Exception {
+            String badJson = "{"
+                + "\"name\": \"아몬드 초콜릿\","
+                + "\"quantity\": \"과자\","
+                + "}";
+
+            mockMvc.perform(put(
+                    "/api/products/{productId}/options/{optionId}",
+                    product.getId(),
+                    option.getId()
+                )
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(badJson))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error")
+                    .value("'quantity' 필드는 Integer 형식이어야 합니다."));
+        }
+
+        /* ───── 리소스 시나리오 ───── */
+        @Test @DisplayName("[API] 옵션 수정 실패 - 상품 없음 404 Not Found")
+        void update_productNotFound() throws Exception {
+            var dto = new OptionRequestDto("아몬드 초콜릿", 7);
+            mockMvc.perform(put(
+                    "/api/products/{productId}/options/{optionId}",
+                    999L,
+                    option.getId()
+                )
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsBytes(dto)))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.error")
+                    .value("상품을 찾을 수 없습니다."));
+        }
+
+        @Test @DisplayName("[API] 옵션 수정 실패 - 옵션 없음 404 Not Found")
+        void update_optionNotFound() throws Exception {
+            var dto = new OptionRequestDto("아몬드 초콜릿", 7);
+            mockMvc.perform(put(
+                    "/api/products/{productId}/options/{optionId}",
+                    product.getId(),
+                    999L
+                )
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsBytes(dto)))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.error")
+                    .value("옵션을 찾을 수 없습니다."));
+        }
+
+        @Test @DisplayName("[API] 옵션 수정 실패 - 상품 옵션 불일치 409 Conflict")
+        void update_productMismatch() throws Exception {
+            Product otherProduct = productRepository.save(
+                new Product("김밥", 3000, "http://kimbab.png")
+            );
+            Option otherOption = optionRepository.save(
+                new Option(otherProduct, "꼬마 김밥", 4000)
+            );
+            var dto = new OptionRequestDto("Z", 5);
+            mockMvc.perform(put(
+                    "/api/products/{productId}/options/{optionId}",
+                    product.getId(),
+                    otherOption.getId()
+                )
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsBytes(dto)))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.error")
+                    .value(otherOption.getOptionName() + " 옵션은 " + product.getName() + " 상품에 속하지 않습니다."));
+        }
+    }
 }

--- a/src/test/java/gift/OptionRepositoryTest.java
+++ b/src/test/java/gift/OptionRepositoryTest.java
@@ -80,7 +80,7 @@ public class OptionRepositoryTest {
         // then ─ 콘텐츠 검증
         assertThat(page.getContent())
             .hasSize(1)
-            .extracting(Option::getOptionName, Option::getOptionQuantity)
+            .extracting(Option::getName, Option::getQuantity)
             .containsExactly(tuple(expectedOptionName, expectedOptionQty));
     }
 
@@ -106,19 +106,19 @@ public class OptionRepositoryTest {
         ));
 
         Optional<Option> option =
-            optionRepository.findByProductIdAndOptionName(product.getId(), "화이트 초콜릿");
+            optionRepository.findByProductIdAndName(product.getId(), "화이트 초콜릿");
 
         assertThat(option)
             .isPresent()
             .get()
-            .satisfies(o -> assertThat(o.getOptionQuantity()).isEqualTo(3));
+            .satisfies(o -> assertThat(o.getQuantity()).isEqualTo(3));
     }
 
     @Test
     @DisplayName("해당 조합이 없으면 Optional.empty()를 반환")
     void returnsEmptyOptionalWhenNotExists() {
         Optional<Option> option =
-            optionRepository.findByProductIdAndOptionName(product.getId(), "두바이 초콜릿");
+            optionRepository.findByProductIdAndName(product.getId(), "두바이 초콜릿");
 
         assertThat(option).isNotPresent();
     }

--- a/src/test/java/gift/OptionRepositoryTest.java
+++ b/src/test/java/gift/OptionRepositoryTest.java
@@ -1,0 +1,97 @@
+package gift;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+import gift.entity.Option;
+import gift.entity.Product;
+import gift.repository.OptionRepository;
+import gift.repository.ProductRepository;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+@DataJpaTest
+public class OptionRepositoryTest {
+
+    @Autowired
+    private OptionRepository optionRepository;
+
+    @Autowired
+    private ProductRepository productRepository;
+
+    private Product product;
+
+    @BeforeEach
+    void setUp() {
+        productRepository.deleteAll();
+        optionRepository.deleteAll();
+
+        product = new Product("초콜릿", 1000, "http://choco.png");
+        productRepository.save(product);
+    }
+
+    @ParameterizedTest(name = "[page={0}] optionName={1}, optionQuantity={2}, first={3}, prev={4}, next={5}")
+    @CsvSource({
+        // page, optionName, optionQuantity, first, prev, next
+        "0, 아몬드 초콜릿, 4, true, false, true",
+        "1, 화이트 초콜릿, 3, false, true, true",
+        "2, 다크 초콜릿, 2, false, true, false"
+    })
+    @DisplayName("상품 옵션 페이지네이션 조회")
+    void findAllByProductId_shouldReturnPagedOptions(
+        int pageIndex,
+        String expectedOptionName,
+        int expectedOptionQty,
+        boolean expectedFirst,
+        boolean expectedPrev,
+        boolean expectedNext
+    ) {
+        // given ─ 옵션 3개 저장
+        optionRepository.saveAll(List.of(
+            new Option(product, "다크 초콜릿", 2),
+            new Option(product, "화이트 초콜릿", 3),
+            new Option(product, "아몬드 초콜릿", 4)
+        ));
+
+        // when ─ pageSize=1, id desc
+        Pageable pageable = PageRequest.of(pageIndex, 1, Sort.by("id").descending());
+        Page<Option> page = optionRepository.findAllByProductId(product.getId(), pageable);
+
+        // then ─ 메타데이터
+        assertThat(page.getTotalElements()).isEqualTo(3);
+        assertThat(page.getTotalPages()).isEqualTo(3);
+        assertThat(page.getNumber()).isEqualTo(pageIndex);
+        assertThat(page.getSize()).isEqualTo(1);
+        assertThat(page.isFirst()).isEqualTo(expectedFirst);
+        assertThat(page.hasPrevious()).isEqualTo(expectedPrev);
+        assertThat(page.hasNext()).isEqualTo(expectedNext);
+
+        // then ─ 콘텐츠 검증
+        assertThat(page.getContent())
+            .hasSize(1)
+            .extracting(Option::getOptionName, Option::getOptionQuantity)
+            .containsExactly(tuple(expectedOptionName, expectedOptionQty));
+    }
+
+    @Test
+    @DisplayName("옵션이 없으면 빈 페이지를 반환")
+    void returnsEmptyPageWhenNotFound() {
+        Pageable pageable = PageRequest.of(0, 5);
+
+        Page<Option> page = optionRepository.findAllByProductId(-999L, pageable);
+
+        assertThat(page).isEmpty();
+        assertThat(page.getTotalElements()).isZero();
+        assertThat(page.getTotalPages()).isZero();
+    }
+}

--- a/src/test/java/gift/OptionRepositoryTest.java
+++ b/src/test/java/gift/OptionRepositoryTest.java
@@ -8,6 +8,7 @@ import gift.entity.Product;
 import gift.repository.OptionRepository;
 import gift.repository.ProductRepository;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -93,5 +94,32 @@ public class OptionRepositoryTest {
         assertThat(page).isEmpty();
         assertThat(page.getTotalElements()).isZero();
         assertThat(page.getTotalPages()).isZero();
+    }
+
+    @Test
+    @DisplayName("상품 ID + 옵션명으로 옵션을 조회")
+    void returnsSingleOption() {
+        optionRepository.saveAll(List.of(
+            new Option(product, "다크 초콜릿", 2),
+            new Option(product, "화이트 초콜릿", 3),
+            new Option(product, "아몬드 초콜릿", 4)
+        ));
+
+        Optional<Option> option =
+            optionRepository.findByProductIdAndOptionName(product.getId(), "화이트 초콜릿");
+
+        assertThat(option)
+            .isPresent()
+            .get()
+            .satisfies(o -> assertThat(o.getOptionQuantity()).isEqualTo(3));
+    }
+
+    @Test
+    @DisplayName("해당 조합이 없으면 Optional.empty()를 반환")
+    void returnsEmptyOptionalWhenNotExists() {
+        Optional<Option> option =
+            optionRepository.findByProductIdAndOptionName(product.getId(), "두바이 초콜릿");
+
+        assertThat(option).isNotPresent();
     }
 }

--- a/src/test/java/gift/ProductRepositoryTest.java
+++ b/src/test/java/gift/ProductRepositoryTest.java
@@ -4,6 +4,8 @@ import gift.entity.Product;
 import gift.repository.ProductRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.data.domain.Page;
@@ -37,9 +39,22 @@ public class ProductRepositoryTest {
         assertThat(found.getImageUrl()).isEqualTo("http://example.com/img.png");
     }
 
-    @Test
+    @ParameterizedTest(name = "[page={0}] name={1}, price={2}, url={3}")
+    @CsvSource({
+        // page, name, price, imageUrl, isFirst, hasPrevious, hasNext
+        "0, C, 3, http://exampleC.com/img.png, true,  false, true",
+        "1, B, 2, http://exampleB.com/img.png, false, true,  true",
+        "2, A, 1, http://exampleA.com/img.png, false, true,  false"
+    })
     @DisplayName("findAll: 저장된 상품 리스트를 모두 반환")
-    void findAll_shouldReturnAllSaved() {
+    void findAll_shouldReturnAllSaved(int pageIndex,
+        String expectedName,
+        int expectedPrice,
+        String expectedImageUrl,
+        boolean expectedFirst,
+        boolean expectedPrev,
+        boolean expectedNext
+    ) {
         // given — 기존 데이터 삭제 후 3개 상품 저장
         productRepository.deleteAll();
         productRepository.saveAll(List.of(
@@ -50,64 +65,33 @@ public class ProductRepositoryTest {
 
         // when — 페이지 크기 1, id 내림차순 정렬
         Pageable pageable = PageRequest.of(
-                0,                             // page number
-                1,                                        // page size
-                Sort.by("id").descending()      // sort by id desc
+            pageIndex,                             // page number
+            1,                                        // page size
+            Sort.by("id").descending()      // sort by id desc
         );
-        // 첫 번째 페이지 조회
-        Page<Product> page0 = productRepository.findAll(pageable);
 
-        // then — 메타데이터 검증
-        assertThat(page0.getTotalElements()).isEqualTo(3);     // 전체 요소 수
-        assertThat(page0.getTotalPages()).isEqualTo(3);        // 전체 페이지 수
-        assertThat(page0.getNumber()).isZero();                        // 현재 페이지 인덱스
-        assertThat(page0.getSize()).isEqualTo(1);              // 페이지 크기
+        Page<Product> page = productRepository.findAll(pageable);
 
-        // then — 첫 번째 페이지 콘텐츠 검증
-        assertThat(page0.getContent())
-                .extracting(Product::getName)
-                .containsExactly("C");
-        assertThat(page0.getContent())
-                .extracting(Product::getPrice)
-                .containsExactly(3);
-        assertThat(page0.getContent())
-                .extracting(Product::getImageUrl)
-                .containsExactly("http://exampleC.com/img.png");
-        assertThat(page0.isFirst()).isTrue();
-        assertThat(page0.hasPrevious()).isFalse();
-        assertThat(page0.hasNext()).isTrue();
+        // then — 메타데이터 검증 (공통값)
+        assertThat(page.getTotalElements()).isEqualTo(3);
+        assertThat(page.getTotalPages()).isEqualTo(3);
+        assertThat(page.getNumber()).isEqualTo(pageIndex);
+        assertThat(page.getSize()).isEqualTo(1);
 
-        // when — 두 번째 페이지 조회
-        Page<Product> page1 = productRepository.findAll(pageable.withPage(1));
+        // then — 콘텐츠 검증
+        assertThat(page.getContent())
+            .extracting(Product::getName)
+            .containsExactly(expectedName);
+        assertThat(page.getContent())
+            .extracting(Product::getPrice)
+            .containsExactly(expectedPrice);
+        assertThat(page.getContent())
+            .extracting(Product::getImageUrl)
+            .containsExactly(expectedImageUrl);
 
-        // then — 두 번째 페이지 콘텐츠 검증
-        assertThat(page1.getContent())
-                .extracting(Product::getName)
-                .containsExactly("B");
-        assertThat(page1.getContent())
-                .extracting(Product::getPrice)
-                .containsExactly(2);
-        assertThat(page1.getContent())
-                .extracting(Product::getImageUrl)
-                .containsExactly("http://exampleB.com/img.png");
-        assertThat(page1.hasPrevious()).isTrue();
-        assertThat(page1.hasNext()).isTrue();
-
-        // when — 마지막 페이지 조회
-        Page<Product> page2 = productRepository.findAll(pageable.withPage(2));
-
-        // then — 마지막 페이지 콘텐츠 검증
-        assertThat(page2.getContent())
-                .extracting(Product::getName)
-                .containsExactly("A");
-        assertThat(page2.getContent())
-                .extracting(Product::getPrice)
-                .containsExactly(1);
-        assertThat(page2.getContent())
-                .extracting(Product::getImageUrl)
-                .containsExactly("http://exampleA.com/img.png");
-        assertThat(page2.isLast()).isTrue();
-        assertThat(page2.hasPrevious()).isTrue();
-        assertThat(page2.hasNext()).isFalse();
+        // then — 네비게이션 플래그 검증
+        assertThat(page.isFirst()).isEqualTo(expectedFirst);
+        assertThat(page.hasPrevious()).isEqualTo(expectedPrev);
+        assertThat(page.hasNext()).isEqualTo(expectedNext);
     }
 }


### PR DESCRIPTION
## 🚀 Step 3 – 상품 옵션 기능 구현 PR

### 1. 개요

- 상품 옵션(Option) 엔티티 도입 및 CRUD 전 기능 구현

- REST API + 관리자/일반 사용자 Thymeleaf 화면 동시 제공 ( 상품 상세 페이지에 상품 옵션을 제공 )

- Repository 단위 테스트 + Controller 통합 테스트 ( 4 + 30 case ) 로 전체 시나리오 검증

---

### 2. 주요 변경 내역

| 구조 | 변경 파일 | 요약 |
| -- | -- | -- |
| Domain | Option.java, OptionRepository.java | Product 매핑 / 상품 수량 차감 subtract 메서드 구현, Bean Validation 패턴·수량 제약
Repository | OptionRepository.java | findAllByProductId ( 페이지 방식 ), findByProductIdAndOptionName 구현
Service | OptionService.java | 목록/추가/수정/재고차감/삭제, 중복·재고부족 검증
Controller | OptionController.java, OptionRequest/Response DTO | GET 목록 200 OK, POST 201 Created +Location, PATCH subtract 204 No Content, PUT update 200 OK, DELETE 204 No Content
test(option): E2E Test / Unit Test | OptionControllerTest.java, OptionRepositoryTest.java | 생성/수정/차감/삭제 + 유효성 5종, 리소스 오류 등 검증
docs(readme): Step3 spec | README.md | 기능 요구·API 스펙·테스트 범위·DDL 설명 추가

---

### 3. API 스펙 요약

| 메서드 | Endpoint | 응답 | 비고
-- | -- | -- | --
GET | `/api/products/{productId}/options` | 200 OK List<Option> | 페이지네이션 불필요 ( 현재 범위 )
POST | `/api/products/{productId}/options` | 201 Created + Location 헤더 | 중복 이름 → 409
PUT | `/api/products/{productId}/options/{optionId}` || 200 OK | 부분·전체 갱신 지원
PATCH | `/api/products/{productId}/options/{optionId}/subtract` | 204 No Content | 재고 부족 → 409
DELETE | `/api/products/{productId}/options/{optionId}` | 204 No Content |  

---

### 4. 코드 구현 근거

1. **옵션 목록을 “페이지 기반”으로 구현한 이유**  
   - **확장성**: 옵션 종류가 수십~수백 개로 늘어나도 동일 API 스펙으로 무한 스크롤·검색 필터 등 확장이 용이.  
   - **관리 효율**: 관리자 화면에서 페이지·정렬·검색 파라미터만 바꿔 대량 옵션을 손쉽게 관리.  
   - **유연한 UI**: 백엔드는 Page 객체를 주지만, 프런트/Thymeleaf 는 그대로 리스트로 렌더링 가능.  

2. **`subtract()`를 엔티티 내부에 둔 이유**  
   - **불변 조건(invariant) 보장**: `Option`은 “재고 ≥ 0”을 스스로 유지 → 서비스에서 중복 검증 불필요.  
   - **응집도 향상**: 재고 차감 규칙이 엔티티 안에 있어 도메인 규칙이 분산되지 않음.  
   - **DDD 권장 패턴**: 단일 엔티티 필드만 수정하는 간단 검증은 엔티티 메서드로 두어야 유지보수가 용이.  

3. **옵션 UI를 상품 상세 페이지 블록으로 넣은 이유**  
   - **검증된 UX**: 대부분의 이커머스(쿠팡·G마켓 등)가 동일 패턴 사용 → 학습 부담 0.  
   - **전환 최소화**: 옵션 확인·선택을 위해 추가 페이지 이동이 필요 없어 구매 흐름 단축.  
   - **모듈성**: Thymeleaf fragment 로 분리해 동일 블록을 관리자 상세·사용자 상세에 모두 삽입 가능.

> ⚡ 요약: 페이지 기반 API로 확장성 확보, `subtract()` 엔티티 배치로 도메인 규칙 응집,  
> 옵션 UI를 상세 페이지 내 블록화해 사용자·관리자 모두 편의성 향상.

---

### 5. 상품 옵션 UI

<img width="833" height="897" alt="image" src="https://github.com/user-attachments/assets/57ed596c-fd17-471f-aea2-7f81533c38b9" />

---

아직 상품 옵션 기능에 관련된 관리자 뷰 Controller ( 옵션 추가/수정/삭제/수량 차감 ) 는 구현하지 못했습니다.
현재 상품 옵션 선택 기능만 구현한 상태입니다.

리뷰 부탁드립니다! 🎉

추가 수정사항이 있으면 바로 수정해서 push 하도록 하겠습니다.

---

추가로 저번 Step 2 페이지네이션 피드백 주신 것에 대한 답변도 남겼으니 확인해 주시면 감사하겠습니다.
https://github.com/next-step/spring-gift-enhancement/pull/197#pullrequestreview-3029744119