### PR TITLE
경북대 BE 김동규 3단계 - 상품 옵션

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,21 @@
 
 - 전체 상품 조회에 페이지네이션 구현
 - 전체 위시리스트 조회에 페이지네이션 구현
+
+# step3 구현 사항
+
+- 상품 정보에 옵션을 추가
+
+- 옵션 API
+    - 옵션 생성: POST /api/products/{productId}/options
+    - 옵션 조회: GET /api/products/{productId}/options
+    - 옵션 삭제(전체) DELETE /api/products/{productId}/options
+    - 옵션 삭제(단건) DELETE /api/products/{productId}/options/{optionId}
+
+- 옵션 이름 요구사항 -> OptionRequestDto에 validation 어노테이션을 통해 구현
+    - 공백을 포함하여 최대 50자
+    - 특수문자는 (),[],+,-,&,/,_ 만 가능
+- 동일한 상품 내의 옵션 이름은 중복불가능
+    - product의 옵션 리스트를 조회하여 중복 체크
+- 상품 옵션의 수량을 지정된 숫자만큼 빼는 기능 구현
+    - option 엔티티에 subtractQuantity() 메서드 

--- a/src/main/java/gift/controller/ProductController.java
+++ b/src/main/java/gift/controller/ProductController.java
@@ -59,7 +59,7 @@ public class ProductController {
   @PostMapping("/{id}/options")
   public ResponseEntity<OptionResponseDto> createOption(@PathVariable Long id,
       @Valid @RequestBody OptionRequestDto requestDto) {
-    return new ResponseEntity<>(optionService.createOption(id, requestDto), HttpStatus.OK);
+    return new ResponseEntity<>(optionService.createOption(id, requestDto), HttpStatus.CREATED);
   }
 
   @PatchMapping("/{id}")

--- a/src/main/java/gift/controller/ProductController.java
+++ b/src/main/java/gift/controller/ProductController.java
@@ -1,9 +1,13 @@
 package gift.controller;
 
+import gift.dto.option.OptionRequestDto;
+import gift.dto.option.OptionResponseDto;
 import gift.dto.product.ProductRequestDto;
 import gift.dto.product.ProductResponseDto;
+import gift.service.option.OptionService;
 import gift.service.product.ProductService;
 import jakarta.validation.Valid;
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
@@ -22,38 +26,65 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/products")
 public class ProductController {
 
-  private final ProductService service;
+  private final ProductService productService;
+  private final OptionService optionService;
 
-  public ProductController(ProductService service) {
-    this.service = service;
+  public ProductController(ProductService productService, OptionService optionService) {
+    this.productService = productService;
+    this.optionService = optionService;
   }
 
   @GetMapping
   public ResponseEntity<Page<ProductResponseDto>> findAllProduct(
       @PageableDefault(page = 0, size = 5) Pageable pageable) {
-    return new ResponseEntity<>(service.findAllProductAsPage(pageable), HttpStatus.OK);
+    return new ResponseEntity<>(productService.findAllProductAsPage(pageable), HttpStatus.OK);
   }
 
   @GetMapping("/{id}")
   public ResponseEntity<ProductResponseDto> findProductById(@PathVariable Long id) {
-    return new ResponseEntity<>(service.findProductById(id), HttpStatus.OK);
+    return new ResponseEntity<>(productService.findProductById(id), HttpStatus.OK);
+  }
+
+  @GetMapping("/{id}/options")
+  public ResponseEntity<List<OptionResponseDto>> findOptionById(@PathVariable Long id) {
+    return new ResponseEntity<>(optionService.findByProductId(id), HttpStatus.OK);
   }
 
   @PostMapping
   public ResponseEntity<ProductResponseDto> createProduct(
       @Valid @RequestBody ProductRequestDto requestDto) {
-    return new ResponseEntity<>(service.createProduct(requestDto), HttpStatus.CREATED);
+    return new ResponseEntity<>(productService.createProduct(requestDto), HttpStatus.CREATED);
+  }
+
+  @PostMapping("/{id}/options")
+  public ResponseEntity<OptionResponseDto> createOption(@PathVariable Long id,
+      @Valid @RequestBody OptionRequestDto requestDto) {
+    return new ResponseEntity<>(optionService.createOption(id, requestDto), HttpStatus.OK);
   }
 
   @PatchMapping("/{id}")
   public ResponseEntity<ProductResponseDto> updateProduct(@PathVariable Long id,
       @Valid @RequestBody ProductRequestDto requestDto) {
-    return new ResponseEntity<>(service.updateProduct(id, requestDto), HttpStatus.OK);
+    return new ResponseEntity<>(productService.updateProduct(id, requestDto), HttpStatus.OK);
   }
 
   @DeleteMapping("/{id}")
   public ResponseEntity<ProductResponseDto> deleteProduct(@PathVariable Long id) {
-    service.deleteProduct(id);
+    productService.deleteProduct(id);
+    return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+  }
+
+  @DeleteMapping("/{id}/options")
+  public ResponseEntity<OptionResponseDto> deleteAllOption(@PathVariable Long id) {
+    optionService.deleteAllOption(id);
+    return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+  }
+
+  @DeleteMapping("/{productId}/options/{optionId}")
+  public ResponseEntity<OptionResponseDto> deleteByOptionId(
+      @PathVariable(name = "productId") Long productId,
+      @PathVariable(name = "optionId") Long optionId) {
+    optionService.deleteByOptionId(productId, optionId);
     return new ResponseEntity<>(HttpStatus.NO_CONTENT);
   }
 

--- a/src/main/java/gift/dto/option/OptionRequestDto.java
+++ b/src/main/java/gift/dto/option/OptionRequestDto.java
@@ -1,0 +1,27 @@
+package gift.dto.option;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public class OptionRequestDto {
+
+  @NotBlank(message = "이름은 필수입니다.")
+  @Size(max = 50, message = "이름은 최대 50글자입니다")
+  @Pattern(regexp = "^[가-힣a-zA-Z0-9\\(\\)\\[\\]\\+\\-\\&\\/\\_ ]+$", message = "한글, 영문자, 숫자, ( ), [ ], +, -, &, /, _ 만 입력 가능(공백포함)")
+  private String name;
+
+  @Min(value = 0, message = "옵션 수량은 최소 1개 이상입니다.")
+  @Max(value = 100000000, message = "옵션 수량은 1억 미만입니다.")
+  private int quantity;
+
+  public String getName() {
+    return name;
+  }
+
+  public int getQuantity() {
+    return quantity;
+  }
+}

--- a/src/main/java/gift/dto/option/OptionResponseDto.java
+++ b/src/main/java/gift/dto/option/OptionResponseDto.java
@@ -1,0 +1,32 @@
+package gift.dto.option;
+
+import gift.entity.Option;
+
+public class OptionResponseDto {
+
+  private Long id;
+  private String name;
+  private int quantity;
+
+  public OptionResponseDto(Long id, String name, int quantity) {
+    this.id = id;
+    this.name = name;
+    this.quantity = quantity;
+  }
+
+  public OptionResponseDto(Option option) {
+    this(option.getId(), option.getName(), option.getQuantity());
+  }
+
+  public Long getId() {
+    return id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public int getQuantity() {
+    return quantity;
+  }
+}

--- a/src/main/java/gift/entity/Option.java
+++ b/src/main/java/gift/entity/Option.java
@@ -1,0 +1,61 @@
+package gift.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+
+@Entity
+public class Option {
+
+  @Id
+  @GeneratedValue
+  Long id;
+
+  String name;
+
+  int quantity;
+
+  @ManyToOne
+  @JoinColumn(name = "product_id")
+  Product product;
+
+  public Option() {
+  }
+
+  public Option(Long id, String name, int quantity, Product product) {
+    this.id = id;
+    this.name = name;
+    this.quantity = quantity;
+    this.product = product;
+  }
+
+  public Option(String name, int quantity, Product product) {
+    this(null, name, quantity, product);
+  }
+
+  public Long getId() {
+    return id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public int getQuantity() {
+    return quantity;
+  }
+
+  public Product getProduct() {
+    return product;
+  }
+
+  public void setProduct(Product product) {
+    this.product = product;
+  }
+
+  public int subtractQuantity(int quantity) {
+    return this.quantity -= quantity;
+  }
+}

--- a/src/main/java/gift/entity/Option.java
+++ b/src/main/java/gift/entity/Option.java
@@ -51,7 +51,7 @@ public class Option {
     return product;
   }
 
-  public void setProduct(Product product) {
+  protected void setProduct(Product product) {
     this.product = product;
   }
 

--- a/src/main/java/gift/entity/Option.java
+++ b/src/main/java/gift/entity/Option.java
@@ -1,5 +1,6 @@
 package gift.entity;
 
+import gift.exception.CantSubtractException;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
@@ -56,6 +57,9 @@ public class Option {
   }
 
   public int subtractQuantity(int quantity) {
+    if (this.quantity < quantity) {
+      throw new CantSubtractException("옵션 수량보다 더 큰 수량은 불가능합니다.");
+    }
     return this.quantity -= quantity;
   }
 }

--- a/src/main/java/gift/entity/Product.java
+++ b/src/main/java/gift/entity/Product.java
@@ -5,6 +5,9 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 public class Product {
@@ -21,6 +24,9 @@ public class Product {
 
   @Column(nullable = false, name = "IMAGE_URL")
   private String imageUrl;
+
+  @OneToMany(mappedBy = "product")
+  private List<Option> options = new ArrayList<>();
 
   public Product() {
 
@@ -57,6 +63,10 @@ public class Product {
     return imageUrl;
   }
 
+  public List<Option> getOptions() {
+    return options;
+  }
+
   public boolean isNameHasWord(String word) {
     return this.name.contains(word);
   }
@@ -65,5 +75,22 @@ public class Product {
     this.name = name;
     this.price = price;
     this.imageUrl = imageUrl;
+  }
+
+  public void addOption(Option option) {
+    this.options.add(option);
+    option.setProduct(this);
+  }
+
+  public void removeOption(Option option) {
+    this.options.remove(option);
+    option.setProduct(null);
+  }
+
+  public void removeAllOption() {
+    for (Option option : this.options) {
+      option.setProduct(null);
+    }
+    this.options.clear();
   }
 }

--- a/src/main/java/gift/exception/CantSubtractException.java
+++ b/src/main/java/gift/exception/CantSubtractException.java
@@ -1,0 +1,8 @@
+package gift.exception;
+
+public class CantSubtractException extends RuntimeException {
+
+  public CantSubtractException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/gift/exception/DuplicatedOptionException.java
+++ b/src/main/java/gift/exception/DuplicatedOptionException.java
@@ -1,0 +1,8 @@
+package gift.exception;
+
+public class DuplicatedOptionException extends RuntimeException {
+
+  public DuplicatedOptionException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/gift/exception/GlobalExceptionHandler.java
+++ b/src/main/java/gift/exception/GlobalExceptionHandler.java
@@ -71,4 +71,12 @@ public class GlobalExceptionHandler {
         exception.getMessage());
     return new ResponseEntity<>(errorResponse, HttpStatus.CONFLICT);
   }
+
+  @ExceptionHandler(value = CantSubtractException.class)
+  public ResponseEntity<CustomErrorResponse> handleCantSubtractException(
+      CantSubtractException exception) {
+    CustomErrorResponse errorResponse = new CustomErrorResponse(HttpStatus.BAD_REQUEST,
+        exception.getMessage());
+    return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
+  }
 }

--- a/src/main/java/gift/exception/GlobalExceptionHandler.java
+++ b/src/main/java/gift/exception/GlobalExceptionHandler.java
@@ -63,4 +63,12 @@ public class GlobalExceptionHandler {
         exception.getMessage());
     return new ResponseEntity<>(errorResponse, HttpStatus.UNAUTHORIZED);
   }
+
+  @ExceptionHandler(value = DuplicatedOptionException.class)
+  public ResponseEntity<CustomErrorResponse> handleDuplicateOptionException(
+      DuplicatedOptionException exception) {
+    CustomErrorResponse errorResponse = new CustomErrorResponse(HttpStatus.CONFLICT,
+        exception.getMessage());
+    return new ResponseEntity<>(errorResponse, HttpStatus.CONFLICT);
+  }
 }

--- a/src/main/java/gift/repository/option/OptionJpaRepository.java
+++ b/src/main/java/gift/repository/option/OptionJpaRepository.java
@@ -1,0 +1,13 @@
+package gift.repository.option;
+
+import gift.entity.Option;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface OptionJpaRepository extends JpaRepository<Option, Long> {
+
+  void deleteByProductId(Long productId);
+
+  void deleteByProductIdAndId(Long productId, Long id);
+}

--- a/src/main/java/gift/service/option/OptionService.java
+++ b/src/main/java/gift/service/option/OptionService.java
@@ -1,0 +1,16 @@
+package gift.service.option;
+
+import gift.dto.option.OptionRequestDto;
+import gift.dto.option.OptionResponseDto;
+import java.util.List;
+
+public interface OptionService {
+
+  List<OptionResponseDto> findByProductId(Long productId);
+
+  OptionResponseDto createOption(Long productId, OptionRequestDto requestDto);
+
+  void deleteAllOption(Long productId);
+
+  void deleteByOptionId(Long productId, Long optionId);
+}

--- a/src/main/java/gift/service/option/OptionServiceImpl.java
+++ b/src/main/java/gift/service/option/OptionServiceImpl.java
@@ -4,6 +4,7 @@ import gift.dto.option.OptionRequestDto;
 import gift.dto.option.OptionResponseDto;
 import gift.entity.Option;
 import gift.entity.Product;
+import gift.exception.DuplicatedOptionException;
 import gift.exception.notfound.ProductNotFoundException;
 import gift.repository.option.OptionJpaRepository;
 import gift.repository.product.ProductJpaRepository;
@@ -39,7 +40,7 @@ public class OptionServiceImpl implements OptionService {
     List<Option> options = product.getOptions();
     for (Option option : options) {
       if (requestDto.getName().equals(option.getName())) {
-        throw new IllegalStateException("중복된 옵션이 존재합니다.");
+        throw new DuplicatedOptionException("중복된 옵션이 존재합니다.");
       }
     }
 

--- a/src/main/java/gift/service/option/OptionServiceImpl.java
+++ b/src/main/java/gift/service/option/OptionServiceImpl.java
@@ -1,0 +1,70 @@
+package gift.service.option;
+
+import gift.dto.option.OptionRequestDto;
+import gift.dto.option.OptionResponseDto;
+import gift.entity.Option;
+import gift.entity.Product;
+import gift.exception.notfound.ProductNotFoundException;
+import gift.repository.option.OptionJpaRepository;
+import gift.repository.product.ProductJpaRepository;
+import jakarta.transaction.Transactional;
+import java.util.List;
+import org.springframework.stereotype.Service;
+
+@Service
+public class OptionServiceImpl implements OptionService {
+
+  private final OptionJpaRepository optionRepository;
+  private final ProductJpaRepository productRepository;
+
+  public OptionServiceImpl(OptionJpaRepository optionRepository,
+      ProductJpaRepository productRepository) {
+    this.optionRepository = optionRepository;
+    this.productRepository = productRepository;
+  }
+
+  @Override
+  public List<OptionResponseDto> findByProductId(Long productId) {
+    return productRepository.findById(productId)
+        .orElseThrow(() -> new ProductNotFoundException("상품이 존재하지 않습니다."))
+        .getOptions().stream().map(OptionResponseDto::new).toList();
+  }
+
+  @Transactional
+  @Override
+  public OptionResponseDto createOption(Long productId, OptionRequestDto requestDto) {
+    Product product = productRepository.findById(productId)
+        .orElseThrow(() -> new ProductNotFoundException("상품이 존재하지 않습니다."));
+
+    List<Option> options = product.getOptions();
+    for (Option option : options) {
+      if (requestDto.getName().equals(option.getName())) {
+        throw new IllegalStateException("중복된 옵션이 존재합니다.");
+      }
+    }
+
+    Option option = optionRepository.save(
+        new Option(requestDto.getName(), requestDto.getQuantity(), product));
+    product.addOption(option);
+
+    return new OptionResponseDto(option);
+  }
+
+  @Transactional
+  @Override
+  public void deleteAllOption(Long productId) {
+    productRepository.findById(productId)
+        .orElseThrow(() -> new ProductNotFoundException("삭제하려는 상품이 존재하지 않습니다."))
+        .removeAllOption();
+    optionRepository.deleteByProductId(productId);
+  }
+
+  @Transactional
+  @Override
+  public void deleteByOptionId(Long productId, Long optionId) {
+    productRepository.findById(productId)
+        .orElseThrow(() -> new ProductNotFoundException("삭제하려는 상품이 존재하지 않습니다."))
+        .removeOption(optionRepository.findById(optionId).orElseThrow());
+    optionRepository.deleteByProductIdAndId(productId, optionId);
+  }
+}

--- a/src/main/java/gift/service/product/ProductServiceImpl.java
+++ b/src/main/java/gift/service/product/ProductServiceImpl.java
@@ -5,6 +5,7 @@ import gift.dto.product.ProductResponseDto;
 import gift.entity.Product;
 import gift.exception.NameHasKakaoException;
 import gift.exception.notfound.ProductNotFoundException;
+import gift.repository.option.OptionJpaRepository;
 import gift.repository.product.ProductJpaRepository;
 import jakarta.transaction.Transactional;
 import java.util.ArrayList;
@@ -16,14 +17,17 @@ import org.springframework.stereotype.Service;
 @Service
 public class ProductServiceImpl implements ProductService {
 
-  private final ProductJpaRepository repository;
+  private final ProductJpaRepository productRepository;
+  private final OptionJpaRepository optionRepository;
 
-  public ProductServiceImpl(ProductJpaRepository repository) {
-    this.repository = repository;
+  public ProductServiceImpl(ProductJpaRepository productRepository,
+      OptionJpaRepository optionRepository) {
+    this.productRepository = productRepository;
+    this.optionRepository = optionRepository;
   }
 
   public List<ProductResponseDto> findAllProduct() {
-    List<Product> allProduct = repository.findAll();
+    List<Product> allProduct = productRepository.findAll();
     List<ProductResponseDto> responseDtoList = new ArrayList<>();
     for (Product product : allProduct) {
       ProductResponseDto responseDto = new ProductResponseDto(product);
@@ -34,11 +38,11 @@ public class ProductServiceImpl implements ProductService {
 
   @Override
   public Page<ProductResponseDto> findAllProductAsPage(Pageable pageable) {
-    return repository.findAll(pageable).map(ProductResponseDto::new);
+    return productRepository.findAll(pageable).map(ProductResponseDto::new);
   }
 
   public ProductResponseDto findProductById(Long id) {
-    return repository.findById(id)
+    return productRepository.findById(id)
         .map(ProductResponseDto::new)
         .orElseThrow(() -> new ProductNotFoundException("product가 없습니다."));
   }
@@ -50,7 +54,7 @@ public class ProductServiceImpl implements ProductService {
     if (checkProduct.isNameHasWord("카카오") && !requestDto.getMdOk()) {
       throw new NameHasKakaoException("상품 이름에 '카카오'가 포함되어 있습니다. 담당 MD와 협의가 필요합니다.");
     }
-    Product product = repository.save(
+    Product product = productRepository.save(
         new Product(requestDto.getName(), requestDto.getPrice(),
             requestDto.getImageUrl()));
     return new ProductResponseDto(product);
@@ -58,7 +62,7 @@ public class ProductServiceImpl implements ProductService {
 
   @Transactional
   public ProductResponseDto updateProduct(Long id, ProductRequestDto requestDto) {
-    Product product = repository.findById(id)
+    Product product = productRepository.findById(id)
         .orElseThrow(() -> new ProductNotFoundException("product가 없습니다."));
     if (product.isNameHasWord("카카오") && !requestDto.getMdOk()) {
       throw new NameHasKakaoException("상품 이름에 '카카오'가 포함되어 있습니다. 담당 MD와 협의가 필요합니다.");
@@ -70,6 +74,7 @@ public class ProductServiceImpl implements ProductService {
 
   @Transactional
   public void deleteProduct(Long id) {
-    repository.deleteById(id);
+    optionRepository.deleteByProductId(id);
+    productRepository.deleteById(id);
   }
 }

--- a/src/test/java/gift/OptionRepositoryTest.java
+++ b/src/test/java/gift/OptionRepositoryTest.java
@@ -1,0 +1,103 @@
+package gift;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import gift.entity.Option;
+import gift.entity.Product;
+import gift.repository.option.OptionJpaRepository;
+import gift.repository.product.ProductJpaRepository;
+import jakarta.persistence.EntityManager;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = Replace.NONE)
+public class OptionRepositoryTest {
+
+  @Autowired
+  EntityManager em;
+  @Autowired
+  private OptionJpaRepository optionRepository;
+  @Autowired
+  private ProductJpaRepository productRepository;
+
+  @Test
+  void 옵션저장() {
+    Product product = new Product("product", 1000L, "https://naver.com");
+    Product savedProduct = productRepository.save(product);
+    Option option = new Option("option", 10, savedProduct);
+
+    Option actual = optionRepository.save(option);
+
+    assertThat(actual.getId()).isNotNull();
+    assertThat(actual.getName()).isEqualTo("option");
+    assertThat(actual.getQuantity()).isEqualTo(10);
+    assertThat(actual.getProduct()).isEqualTo(savedProduct);
+  }
+
+  @Test
+  void 옵션조회() {
+    Product product = new Product("product", 1000L, "https://naver.com");
+    Product savedProduct = productRepository.save(product);
+    Option option = new Option("option", 10, savedProduct);
+
+    Option actual = optionRepository.save(option);
+    product.addOption(actual);
+
+    Option actual2 = productRepository.findById(savedProduct.getId()).orElseThrow()
+        .getOptions().get(0);
+
+    assertThat(actual.getId()).isEqualTo(actual2.getId());
+    assertThat(actual.getName()).isEqualTo(actual2.getName());
+    assertThat(actual.getQuantity()).isEqualTo(actual2.getQuantity());
+    assertThat(actual.getProduct()).isEqualTo(actual2.getProduct());
+  }
+
+  @Test
+  void 옵션전체삭제() {
+    Product product = new Product("product", 1000L, "https://naver.com");
+    Product savedProduct = productRepository.save(product);
+    Option option1 = new Option("option", 10, savedProduct);
+    Option option2 = new Option("option2", 10, savedProduct);
+
+    Option actual1 = optionRepository.save(option1);
+    Option actual2 = optionRepository.save(option2);
+    product.addOption(actual1);
+    product.addOption(actual2);
+
+    optionRepository.deleteByProductId(savedProduct.getId());
+    savedProduct.removeAllOption();
+
+    List<Option> options = productRepository.findById(product.getId()).orElseThrow().getOptions();
+
+    assertThat(options.size()).isEqualTo(0);
+  }
+
+  @Test
+  void 옵션단건삭제() {
+    Product product = new Product("product", 1000L, "https://naver.com");
+    Product savedProduct = productRepository.save(product);
+    Option option1 = new Option("option", 10, savedProduct);
+    Option option2 = new Option("option2", 10, savedProduct);
+
+    Option actual1 = optionRepository.save(option1);
+    Option actual2 = optionRepository.save(option2);
+    product.addOption(actual1);
+    product.addOption(actual2);
+
+    optionRepository.deleteByProductIdAndId(savedProduct.getId(), actual1.getId());
+    savedProduct.removeOption(actual1);
+
+    List<Option> options = productRepository.findById(product.getId()).orElseThrow().getOptions();
+
+    assertThat(options.size()).isEqualTo(1);
+    assertThat(options.getFirst().getId()).isEqualTo(actual2.getId());
+    assertThat(options.getFirst().getName()).isEqualTo(actual2.getName());
+    assertThat(options.getFirst().getQuantity()).isEqualTo(actual2.getQuantity());
+    assertThat(options.getFirst().getProduct()).isEqualTo(actual2.getProduct());
+  }
+}

--- a/src/test/java/gift/ProductRepositoryTest.java
+++ b/src/test/java/gift/ProductRepositoryTest.java
@@ -9,6 +9,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = Replace.NONE)
@@ -39,6 +42,20 @@ public class ProductRepositoryTest {
     assertThat(actual.getName()).isEqualTo(actual2.getName());
     assertThat(actual.getPrice()).isEqualTo(actual2.getPrice());
     assertThat(actual.getImageUrl()).isEqualTo(actual2.getImageUrl());
+  }
+
+  @Test
+  void 상품_페이지네이션테스트() {
+    for (int i = 1; i <= 21; i++) {
+      repository.save(new Product("이름", 1L, "https://asd"));
+    }
+    Pageable pageable = PageRequest.of(0, 5);
+
+    Page<Product> result = repository.findAll(pageable);
+
+    assertThat(result.getContent().size()).isEqualTo(5);
+    assertThat(result.getTotalElements()).isEqualTo(22);//datasql로 들어가는 초기데이터로 인해 +1
+    assertThat(result.getTotalPages()).isEqualTo(5);
   }
 
 

--- a/src/test/java/gift/WishRepositoryTest.java
+++ b/src/test/java/gift/WishRepositoryTest.java
@@ -13,6 +13,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = Replace.NONE)
@@ -54,6 +57,25 @@ public class WishRepositoryTest {
     assertThat(actual2.getMember()).isEqualTo(actual.getMember());
     assertThat(actual2.getProduct()).isEqualTo(actual.getProduct());
     assertThat(actual2.getQuantity()).isEqualTo(actual.getQuantity());
+  }
+
+  @Test
+  void 위시리스트_페이지네이션테스트() {
+    Member member = new Member("member@naver.com", "qweqwe");
+    memberRepository.save(member);
+    for (int i = 1; i <= 21; i++) {
+      Product product = new Product("product", 100L, "https://naver.com");
+      productRepository.save(product);
+      Wish wish = new Wish(member, product, 3L);
+      wishRepository.save(wish);
+    }
+    Pageable pageable = PageRequest.of(0, 5);
+
+    Page<Wish> result = wishRepository.findByMemberId(member.getId(), pageable);
+
+    assertThat(result.getContent().size()).isEqualTo(5);
+    assertThat(result.getTotalElements()).isEqualTo(21);
+    assertThat(result.getTotalPages()).isEqualTo(5);
   }
 
   @Test


### PR DESCRIPTION
# step3 구현 사항

- 상품 정보에 옵션을 추가

- 옵션 API
    - 옵션 생성: POST /api/products/{productId}/options
    - 옵션 조회: GET /api/products/{productId}/options
    - 옵션 삭제(전체) DELETE /api/products/{productId}/options
    - 옵션 삭제(단건) DELETE /api/products/{productId}/options/{optionId}

- 옵션 이름 요구사항 : OptionRequestDto에 validation 어노테이션을 통해 구현
    - 공백을 포함하여 최대 50자
    - 특수문자는 (),[],+,-,&,/,_ 만 가능
- 동일한 상품 내의 옵션 이름은 중복불가능
    - product의 옵션 리스트를 조회하여 중복 체크
- 상품 옵션의 수량을 지정된 숫자만큼 빼는 기능 구현
    - option 엔티티에 subtractQuantity() 메서드 

시간내서 피드백 해주셔서 감사합니다!