### PR TITLE
부산대 BE_양준영 3단계 - 상품 옵션

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,13 @@
 
 1. WishlistService의 getWishlistItems 메서드에 페이지네이션 기능을 추가한다.
 2. ProductService의 getProducts 메서드에 페이지네이션 기능을 추가한다.
+
+
+## 3단계 - 상품 옵션
+
+### 구현할 기능 목록
+
+1. 연관 관계 및 Validation에 유의하며 Option 엔티티를 작성한다.
+2. OptionRepository를 작성한다.
+3. OptionService를 작성한다.
+4. OptionController를 작성한다.

--- a/src/main/java/gift/common/SortField.java
+++ b/src/main/java/gift/common/SortField.java
@@ -1,0 +1,6 @@
+package gift.common;
+
+public interface SortField {
+
+    String getFieldName();
+}

--- a/src/main/java/gift/common/dto/PageRequestDto.java
+++ b/src/main/java/gift/common/dto/PageRequestDto.java
@@ -1,0 +1,43 @@
+package gift.common.dto;
+
+import gift.common.SortField;
+import jakarta.validation.constraints.Min;
+import org.hibernate.validator.constraints.Range;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+
+public record PageRequestDto(
+        @Min(value = 1, message = "페이지 번호는 1 이상이어야 합니다.")
+        Integer page,
+
+        @Range(min = 1, max = 100, message = "페이지 크기는 1 이상 100 이하여야 합니다.")
+        Integer size,
+
+        String sortBy,
+
+        Boolean ascending
+) {
+
+    public <T extends Enum<T> & SortField> PageRequest toSafePageable(
+            Class<T> enumClass, T defaultSortField) {
+        int page = this.page != null ? this.page : 1;
+        int size = this.size != null ? this.size : 10;
+        T sortField = defaultSortField;
+        boolean ascending = this.ascending != null ? this.ascending : true;
+
+        if (sortBy != null) {
+            for (T enumValue : enumClass.getEnumConstants()) {
+                if (enumValue.getFieldName().equals(sortBy)) {
+                    sortField = enumValue;
+                }
+            }
+        }
+
+        return PageRequest.of(page - 1, size,
+                Sort.by(
+                        ascending ? Sort.Direction.ASC : Sort.Direction.DESC,
+                        sortField.getFieldName()
+                )
+        );
+    }
+}

--- a/src/main/java/gift/common/dto/PageResponseDto.java
+++ b/src/main/java/gift/common/dto/PageResponseDto.java
@@ -1,0 +1,20 @@
+package gift.common.dto;
+
+import java.util.List;
+import org.springframework.data.domain.Page;
+
+public record PageResponseDto<T>(
+        List<T> content,
+        int page,
+        int size,
+        long totalElements
+) {
+    public static <T> PageResponseDto<T> from(Page<T> page) {
+        return new PageResponseDto<>(
+                page.getContent(),
+                page.getNumber() + 1,
+                page.getSize(),
+                page.getTotalElements()
+        );
+    }
+}

--- a/src/main/java/gift/member/service/MemberService.java
+++ b/src/main/java/gift/member/service/MemberService.java
@@ -58,12 +58,13 @@ public class MemberService {
     public AccessTokenRefreshResponseDto refreshAccessToken(
             AccessTokenRefreshRequestDto requestDto) {
         UUID memberUuid = tokenProvider.getMemberUuidFromRefreshToken(requestDto.refreshToken());
+        String newAccessToken = tokenProvider.generateAccessToken(findMemberByUuid(memberUuid));
 
-        return AccessTokenRefreshResponseDto.of(tokenProvider.generateAccessToken(findByUuid(memberUuid)));
+        return AccessTokenRefreshResponseDto.of(newAccessToken);
     }
 
 
-    public Member findByUuid(UUID uuid) throws EntityNotFoundException {
+    public Member findMemberByUuid(UUID uuid) throws EntityNotFoundException {
         return memberRepository.findByUuid(uuid)
                 .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 회원입니다."));
     }

--- a/src/main/java/gift/product/controller/ProductController.java
+++ b/src/main/java/gift/product/controller/ProductController.java
@@ -1,13 +1,14 @@
 package gift.product.controller;
 
+import gift.common.dto.PageRequestDto;
+import gift.product.enums.ProductSortField;
 import gift.product.dto.ProductCreateRequestDto;
 import gift.product.dto.ProductItemDto;
 import gift.product.dto.ProductUpdateRequestDto;
 import gift.product.service.ProductService;
 import jakarta.validation.Valid;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.web.PageableDefault;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -45,7 +46,10 @@ public class ProductController {
 
     @GetMapping
     public ResponseEntity<Page<ProductItemDto>> getProducts(
-            @PageableDefault(sort = "id") Pageable pageable) {
+            @Valid @ModelAttribute PageRequestDto pageRequestDto) {
+        PageRequest pageable = pageRequestDto.toSafePageable(
+                ProductSortField.class, ProductSortField.NAME);
+
         var productItemDtos = productService.getProducts(pageable);
         return ResponseEntity.status(HttpStatus.OK).body(productItemDtos);
     }

--- a/src/main/java/gift/product/controller/ProductController.java
+++ b/src/main/java/gift/product/controller/ProductController.java
@@ -1,13 +1,13 @@
 package gift.product.controller;
 
 import gift.common.dto.PageRequestDto;
+import gift.common.dto.PageResponseDto;
 import gift.product.enums.ProductSortField;
 import gift.product.dto.ProductCreateRequestDto;
 import gift.product.dto.ProductItemDto;
 import gift.product.dto.ProductUpdateRequestDto;
 import gift.product.service.ProductService;
 import jakarta.validation.Valid;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -45,13 +45,13 @@ public class ProductController {
     }
 
     @GetMapping
-    public ResponseEntity<Page<ProductItemDto>> getProducts(
+    public ResponseEntity<PageResponseDto<ProductItemDto>> getProducts(
             @Valid @ModelAttribute PageRequestDto pageRequestDto) {
         PageRequest pageable = pageRequestDto.toSafePageable(
                 ProductSortField.class, ProductSortField.NAME);
 
-        var productItemDtos = productService.getProducts(pageable);
-        return ResponseEntity.status(HttpStatus.OK).body(productItemDtos);
+        var pageResponseDto = productService.getProducts(pageable);
+        return ResponseEntity.status(HttpStatus.OK).body(pageResponseDto);
     }
 
     @GetMapping("{id}")

--- a/src/main/java/gift/product/dto/ProductCreateRequestDto.java
+++ b/src/main/java/gift/product/dto/ProductCreateRequestDto.java
@@ -12,9 +12,11 @@ public record ProductCreateRequestDto(
         @Length(max = 15, message = "상품 이름은 최대 15자까지만 입력 가능합니다.")
         @Pattern(regexp = "[0-9a-zA-Zㄱ-ㅎ가-힣 ()\\[\\]+\\-&/_]+", message = "상품 이름은 한글, 영문, 숫자, 공백, 특수문자((), [], +, -, &, /, _)만 사용할 수 있습니다.")
         String name,
+
         @NotNull(message = "상품 가격은 필수입니다.")
         @PositiveOrZero(message = "상품 가격은 0 이상이어야 합니다.")
         Long price,
+
         @URL(message = "유효한 URL 형식이어야 합니다.")
         String imageUrl
 ) {

--- a/src/main/java/gift/product/enums/ProductSortField.java
+++ b/src/main/java/gift/product/enums/ProductSortField.java
@@ -1,0 +1,21 @@
+package gift.product.enums;
+
+import gift.common.SortField;
+
+public enum ProductSortField implements SortField {
+    ID("id"),
+    NAME("name"),
+    PRICE("price"),
+    CREATED_AT("createdAt"),
+    UPDATED_AT("updatedAt");
+
+    private final String fieldName;
+
+    ProductSortField(String fieldName) {
+        this.fieldName = fieldName;
+    }
+
+    public String getFieldName() {
+        return fieldName;
+    }
+}

--- a/src/main/java/gift/product/option/controller/OptionController.java
+++ b/src/main/java/gift/product/option/controller/OptionController.java
@@ -1,0 +1,47 @@
+package gift.product.option.controller;
+
+import gift.product.option.dto.OptionCreateRequestDto;
+import gift.product.option.dto.OptionItemDto;
+import gift.product.option.service.OptionService;
+import jakarta.validation.Valid;
+import java.util.List;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/products/{productId}/options")
+public class OptionController {
+
+    private final OptionService optionService;
+
+    public OptionController(OptionService optionService) {
+        this.optionService = optionService;
+    }
+
+    @PostMapping
+    public ResponseEntity<OptionItemDto> createOption(
+            @PathVariable Long productId,
+            @Valid @RequestBody OptionCreateRequestDto optionCreateRequestDto) {
+        var createdOptionItemDto = optionService.createOption(productId, optionCreateRequestDto);
+        return ResponseEntity.status(HttpStatus.CREATED).body(createdOptionItemDto);
+    }
+
+    @GetMapping
+    public ResponseEntity<List<OptionItemDto>> getOptions(@PathVariable Long productId) {
+        var optionItemDtos = optionService.getProductOptions(productId);
+        return ResponseEntity.status(HttpStatus.OK).body(optionItemDtos);
+    }
+
+    @DeleteMapping("{optionId}")
+    public ResponseEntity<Void> deleteOption(@PathVariable Long optionId) {
+        optionService.deleteOption(optionId);
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    }
+}

--- a/src/main/java/gift/product/option/dto/OptionCreateRequestDto.java
+++ b/src/main/java/gift/product/option/dto/OptionCreateRequestDto.java
@@ -1,0 +1,24 @@
+package gift.product.option.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import org.hibernate.validator.constraints.Length;
+import org.hibernate.validator.constraints.Range;
+
+public record OptionCreateRequestDto(
+        @NotBlank(message = "옵션 이름은 필수입니다.")
+        @Pattern(regexp = "[0-9a-zA-Zㄱ-ㅎ가-힣 ()\\[\\]+\\-&/_]+",
+                message = "옵션 이름은 한글, 영문, 숫자, 공백, 특수문자((), [], +, -, &, /, _)만 사용할 수 있습니다.")
+        @Length(max = 50, message = "옵션 이름은 최대 50자까지만 입력 가능합니다.")
+        String name,
+
+        @NotNull(message = "옵션 수량은 필수입니다.")
+        @Range(min = 1, max = 100_000_000, message = "옵션 수량은 1 이상 100,000,000 이하여야 합니다.")
+        Integer quantity
+) {
+
+    public static OptionCreateRequestDto from(String name, Integer quantity) {
+        return new OptionCreateRequestDto(name, quantity);
+    }
+}

--- a/src/main/java/gift/product/option/dto/OptionItemDto.java
+++ b/src/main/java/gift/product/option/dto/OptionItemDto.java
@@ -1,0 +1,14 @@
+package gift.product.option.dto;
+
+import gift.product.option.entity.Option;
+
+public record OptionItemDto(
+        Long id,
+        String name,
+        Integer quantity
+) {
+    public static OptionItemDto of(Option option) {
+        return new OptionItemDto(option.getId(), option.getName(), option.getQuantity());
+
+    }
+}

--- a/src/main/java/gift/product/option/entity/Option.java
+++ b/src/main/java/gift/product/option/entity/Option.java
@@ -1,0 +1,76 @@
+package gift.product.option.entity;
+
+import gift.product.entity.Product;
+import gift.product.option.dto.OptionCreateRequestDto;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+
+@Entity
+@Table(
+        uniqueConstraints = {
+                @UniqueConstraint(columnNames = {"name", "product_id"})
+        }
+)
+public class Option {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotNull
+    @NotBlank
+    @Column(nullable = false)
+    private String name;
+
+    @NotNull
+    @Column(nullable = false)
+    private Integer quantity;
+
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY)
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    private Product product;
+
+    public Option() {
+    }
+
+    public Option(Product product, OptionCreateRequestDto requestDto) {
+        this.name = requestDto.name();
+        this.quantity = requestDto.quantity();
+        this.product = product;
+    }
+
+    public void subtract(int quantity) {
+        if (this.quantity - quantity < 1) {
+            throw new IllegalArgumentException("최소 1개의 수량은 남아 있어야 합니다.");
+        }
+        this.quantity -= quantity;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public int getQuantity() {
+        return quantity;
+    }
+
+    public Product getProduct() {
+        return product;
+    }
+}

--- a/src/main/java/gift/product/option/repository/OptionRepository.java
+++ b/src/main/java/gift/product/option/repository/OptionRepository.java
@@ -1,0 +1,16 @@
+package gift.product.option.repository;
+
+import gift.product.option.entity.Option;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface OptionRepository extends JpaRepository<Option, Long> {
+
+    List<Option> getOptionsByProductId(Long productId);
+
+    boolean existsByNameAndProductId(String name, Long productId);
+
+    Long countByProductId(Long productId);
+}

--- a/src/main/java/gift/product/option/service/OptionService.java
+++ b/src/main/java/gift/product/option/service/OptionService.java
@@ -1,0 +1,65 @@
+package gift.product.option.service;
+
+import gift.exception.EntityAlreadyExistsException;
+import gift.exception.EntityNotFoundException;
+import gift.product.entity.Product;
+import gift.product.option.dto.OptionCreateRequestDto;
+import gift.product.option.dto.OptionItemDto;
+import gift.product.option.entity.Option;
+import gift.product.option.repository.OptionRepository;
+import gift.product.service.ProductService;
+import java.util.List;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class OptionService {
+
+    private final OptionRepository optionRepository;
+    private final ProductService productService;
+
+    public OptionService(OptionRepository optionRepository, @Lazy ProductService productService) {
+        this.optionRepository = optionRepository;
+        this.productService = productService;
+    }
+
+    @Transactional
+    public OptionItemDto createOption(Long productId, OptionCreateRequestDto requestDto) {
+        Product product = productService.getProductById(productId);
+        Option newOption = new Option(product, requestDto);
+
+        if (optionRepository.existsByNameAndProductId(newOption.getName(), productId)) {
+            throw new EntityAlreadyExistsException("이미 존재하는 옵션입니다.");
+        }
+        return OptionItemDto.of(optionRepository.save(newOption));
+    }
+
+    @Transactional(readOnly = true)
+    public List<OptionItemDto> getProductOptions(Long productId) {
+        productService.validateProductExists(productId);
+        return optionRepository.getOptionsByProductId(productId)
+                .stream().map(OptionItemDto::of).toList();
+    }
+
+    @Transactional
+    public void deleteOption(Long optionId) {
+        Option option = getOptionById(optionId);
+
+        if(optionRepository.countByProductId(option.getProduct().getId()) == 1) {
+            throw new EntityNotFoundException("최소 하나의 옵션은 남아 있어야 합니다.");
+        }
+        optionRepository.deleteById(optionId);
+    }
+
+    @Transactional
+    public void subtractOptionQuantity(Long optionId, int quantity) {
+        Option option = getOptionById(optionId);
+        option.subtract(quantity);
+    }
+
+    private Option getOptionById(Long optionId) {
+        return optionRepository.findById(optionId)
+                .orElseThrow(() -> new EntityNotFoundException("옵션을 찾을 수 없습니다."));
+    }
+}

--- a/src/main/java/gift/product/service/ProductService.java
+++ b/src/main/java/gift/product/service/ProductService.java
@@ -7,6 +7,8 @@ import gift.product.dto.ProductCreateRequestDto;
 import gift.product.dto.ProductItemDto;
 import gift.product.dto.ProductUpdateRequestDto;
 import gift.product.entity.Product;
+import gift.product.option.dto.OptionCreateRequestDto;
+import gift.product.option.service.OptionService;
 import gift.product.repository.ProductRepository;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -19,15 +21,21 @@ public class ProductService {
 
     private static final String PRODUCT_NOT_FOUND_MESSAGE = "해당 상품을 찾을 수 없습니다.";
     private final ProductRepository productRepository;
+    private final OptionService optionService;
 
-    public ProductService(ProductRepository productRepository) {
+    public ProductService(ProductRepository productRepository, OptionService optionService) {
         this.productRepository = productRepository;
+        this.optionService = optionService;
     }
 
     public ProductItemDto createProduct(ProductCreateRequestDto requestDto) {
         checkRestrictedWords(requestDto.name());
 
         Product newProduct = productRepository.save(new Product(requestDto));
+
+        OptionCreateRequestDto optionCreateRequestDto = OptionCreateRequestDto.from(requestDto.name(), 1);
+        optionService.createOption(newProduct.getId(), optionCreateRequestDto);
+
         return ProductItemDto.from(newProduct);
     }
 
@@ -69,7 +77,7 @@ public class ProductService {
                 .orElseThrow(() -> new EntityNotFoundException(PRODUCT_NOT_FOUND_MESSAGE));
     }
 
-    private void validateProductExists(Long id) {
+    public void validateProductExists(Long id) throws EntityNotFoundException {
         if (!productRepository.existsById(id)) {
             throw new EntityNotFoundException(PRODUCT_NOT_FOUND_MESSAGE);
         }

--- a/src/main/java/gift/product/service/ProductService.java
+++ b/src/main/java/gift/product/service/ProductService.java
@@ -1,5 +1,6 @@
 package gift.product.service;
 
+import gift.common.dto.PageResponseDto;
 import gift.exception.EntityNotFoundException;
 import gift.exception.MdApprovalRequiredException;
 import gift.product.dto.ProductCreateRequestDto;
@@ -7,7 +8,6 @@ import gift.product.dto.ProductItemDto;
 import gift.product.dto.ProductUpdateRequestDto;
 import gift.product.entity.Product;
 import gift.product.repository.ProductRepository;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
@@ -58,8 +58,10 @@ public class ProductService {
                 .toList();
     }
 
-    public Page<ProductItemDto> getProducts(Pageable pageable) {
-        return productRepository.findAll(pageable).map(ProductItemDto::from);
+    public PageResponseDto<ProductItemDto> getProducts(Pageable pageable) {
+        return PageResponseDto.from(
+                productRepository.findAll(pageable).map(ProductItemDto::from)
+        );
     }
 
     public Product getProductById(Long id) throws EntityNotFoundException {

--- a/src/main/java/gift/resolver/LoginMemberArgumentResolver.java
+++ b/src/main/java/gift/resolver/LoginMemberArgumentResolver.java
@@ -37,6 +37,6 @@ public class LoginMemberArgumentResolver implements HandlerMethodArgumentResolve
             throw new InvalidCredentialsException("인증이 필요합니다.");
         }
 
-        return memberService.findByUuid(tokenProvider.getMemberUuidFromAccessToken(token));
+        return memberService.findMemberByUuid(tokenProvider.getMemberUuidFromAccessToken(token));
     }
 }

--- a/src/main/java/gift/token/entity/RefreshToken.java
+++ b/src/main/java/gift/token/entity/RefreshToken.java
@@ -32,10 +32,6 @@ public class RefreshToken extends BaseEntity {
 
     @NotNull
     @Column(nullable = false, updatable = false)
-    private LocalDateTime createdAt;
-
-    @NotNull
-    @Column(nullable = false, updatable = false)
     private LocalDateTime expirationDate;
 
     public RefreshToken() {

--- a/src/main/java/gift/wishlist/controller/WishlistController.java
+++ b/src/main/java/gift/wishlist/controller/WishlistController.java
@@ -1,18 +1,20 @@
 package gift.wishlist.controller;
 
 import gift.annotation.LoginMember;
+import gift.common.dto.PageRequestDto;
 import gift.member.entity.Member;
+import gift.wishlist.enums.WishlistItemSortField;
 import gift.wishlist.dto.WishlistItemResponseDto;
 import gift.wishlist.dto.WishlistUpdateRequestDto;
 import gift.wishlist.service.WishlistService;
 import jakarta.validation.Valid;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -31,7 +33,9 @@ public class WishlistController {
 
     @GetMapping
     public ResponseEntity<Page<WishlistItemResponseDto>> getWishlistItems(
-            @LoginMember Member member, @PageableDefault(sort = "id") Pageable pageable) {
+            @LoginMember Member member, @Valid @ModelAttribute PageRequestDto pageRequestDto) {
+        Pageable pageable = pageRequestDto.toSafePageable(
+                WishlistItemSortField.class, WishlistItemSortField.CREATED_AT);
         var wishlistItems = wishlistService.getWishlistItems(member, pageable);
         return ResponseEntity.ok(wishlistItems);
     }

--- a/src/main/java/gift/wishlist/controller/WishlistController.java
+++ b/src/main/java/gift/wishlist/controller/WishlistController.java
@@ -2,13 +2,13 @@ package gift.wishlist.controller;
 
 import gift.annotation.LoginMember;
 import gift.common.dto.PageRequestDto;
+import gift.common.dto.PageResponseDto;
 import gift.member.entity.Member;
 import gift.wishlist.enums.WishlistItemSortField;
 import gift.wishlist.dto.WishlistItemResponseDto;
 import gift.wishlist.dto.WishlistUpdateRequestDto;
 import gift.wishlist.service.WishlistService;
 import jakarta.validation.Valid;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -32,12 +32,12 @@ public class WishlistController {
     }
 
     @GetMapping
-    public ResponseEntity<Page<WishlistItemResponseDto>> getWishlistItems(
+    public ResponseEntity<PageResponseDto<WishlistItemResponseDto>> getWishlistItems(
             @LoginMember Member member, @Valid @ModelAttribute PageRequestDto pageRequestDto) {
         Pageable pageable = pageRequestDto.toSafePageable(
                 WishlistItemSortField.class, WishlistItemSortField.CREATED_AT);
-        var wishlistItems = wishlistService.getWishlistItems(member, pageable);
-        return ResponseEntity.ok(wishlistItems);
+        var pageResponseDto = wishlistService.getWishlistItems(member, pageable);
+        return ResponseEntity.ok(pageResponseDto);
     }
 
     @PutMapping("/products/{productId}")

--- a/src/main/java/gift/wishlist/dto/WishlistItemResponseDto.java
+++ b/src/main/java/gift/wishlist/dto/WishlistItemResponseDto.java
@@ -7,19 +7,16 @@ import java.time.LocalDateTime;
 public record WishlistItemResponseDto(
         ProductItemDto product,
         int quantity,
-        LocalDateTime createdAt
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
 ) {
-
-    public static WishlistItemResponseDto of(ProductItemDto product, int quantity,
-            LocalDateTime addedAt) {
-        return new WishlistItemResponseDto(product, quantity, addedAt);
-    }
 
     public static WishlistItemResponseDto from(WishlistItem wishlistItem) {
         return new WishlistItemResponseDto(
                 ProductItemDto.from(wishlistItem.getProduct()),
                 wishlistItem.getQuantity(),
-                wishlistItem.getCreatedAt()
+                wishlistItem.getCreatedAt(),
+                wishlistItem.getUpdatedAt()
         );
     }
 }

--- a/src/main/java/gift/wishlist/entity/WishlistItem.java
+++ b/src/main/java/gift/wishlist/entity/WishlistItem.java
@@ -5,7 +5,6 @@ import gift.member.entity.Member;
 import gift.product.entity.Product;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EntityListeners;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -14,13 +13,11 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import jakarta.validation.constraints.NotNull;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
-@EntityListeners(AuditingEntityListener.class)
 @Table(
         uniqueConstraints = {
-                @UniqueConstraint(columnNames = {"member_uuid", "product_id "})
+                @UniqueConstraint(columnNames = {"member_uuid", "product_id"})
         }
 )
 public class WishlistItem extends BaseEntity {

--- a/src/main/java/gift/wishlist/enums/WishlistItemSortField.java
+++ b/src/main/java/gift/wishlist/enums/WishlistItemSortField.java
@@ -1,0 +1,24 @@
+package gift.wishlist.enums;
+
+import gift.common.SortField;
+
+public enum WishlistItemSortField implements SortField {
+    PRODUCT_ID("product.id"),
+    PRODUCT_NAME("product.name"),
+    PRODUCT_PRICE("product.price"),
+    PRODUCT_CREATED_AT("product.createdAt"),
+    PRODUCT_UPDATED_AT("product.updatedAt"),
+
+    CREATED_AT("createdAt"),
+    UPDATED_AT("updatedAt");
+
+    private final String fieldName;
+
+    WishlistItemSortField(String fieldName) {
+        this.fieldName = fieldName;
+    }
+
+    public String getFieldName() {
+        return fieldName;
+    }
+}

--- a/src/main/java/gift/wishlist/service/WishlistService.java
+++ b/src/main/java/gift/wishlist/service/WishlistService.java
@@ -1,5 +1,6 @@
 package gift.wishlist.service;
 
+import gift.common.dto.PageResponseDto;
 import gift.exception.EntityNotFoundException;
 import gift.member.entity.Member;
 import gift.product.entity.Product;
@@ -8,7 +9,6 @@ import gift.wishlist.dto.WishlistItemResponseDto;
 import gift.wishlist.dto.WishlistUpdateRequestDto;
 import gift.wishlist.entity.WishlistItem;
 import gift.wishlist.repository.WishlistRepository;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -40,9 +40,12 @@ public class WishlistService {
         return WishlistItemResponseDto.from(wishlistItem);
     }
 
-    public Page<WishlistItemResponseDto> getWishlistItems(Member member, Pageable pageable) {
-        return wishlistRepository.getWishlistItemsByMemberUuid(member.getUuid(), pageable)
-                .map(WishlistItemResponseDto::from);
+    public PageResponseDto<WishlistItemResponseDto> getWishlistItems(
+            Member member, Pageable pageable) {
+        return PageResponseDto.from(
+                wishlistRepository.getWishlistItemsByMemberUuid(member.getUuid(), pageable)
+                        .map(WishlistItemResponseDto::from)
+        );
     }
 
     @Transactional

--- a/src/test/java/gift/OptionServiceTest.java
+++ b/src/test/java/gift/OptionServiceTest.java
@@ -1,0 +1,183 @@
+package gift;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+
+
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import gift.exception.EntityAlreadyExistsException;
+import gift.exception.EntityNotFoundException;
+import gift.product.entity.Product;
+import gift.product.option.dto.OptionCreateRequestDto;
+import gift.product.option.entity.Option;
+import gift.product.option.repository.OptionRepository;
+import gift.product.option.service.OptionService;
+import gift.product.service.ProductService;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("NonAsciiCharacters")
+@ExtendWith(MockitoExtension.class)
+class OptionServiceTest {
+
+    @Mock
+    private OptionRepository optionRepository;
+
+    @Mock
+    private ProductService productService;
+
+    @Mock
+    private Product testProduct;
+
+    private OptionService optionService;
+    private Option testOption1;
+    private Option testOption2;
+    private OptionCreateRequestDto validCreateRequest;
+
+    @BeforeEach
+    void setUp() {
+        optionService = new OptionService(optionRepository, productService);
+
+        testOption1 = new Option(testProduct, OptionCreateRequestDto.from("1번 옵션", 100));
+        testOption2 = new Option(testProduct, OptionCreateRequestDto.from("2번 옵션", 50));
+
+        validCreateRequest = OptionCreateRequestDto.from("3번 옵션", 30);
+    }
+
+    @Test
+    void 옵션_생성_성공() {
+        var productId = 1L;
+        when(productService.getProductById(productId)).thenReturn(testProduct);
+        when(optionRepository.existsByNameAndProductId(validCreateRequest.name(), productId))
+                .thenReturn(false);
+        when(optionRepository.save(any(Option.class))).thenReturn(testOption1);
+
+        var result = optionService.createOption(productId, validCreateRequest);
+
+        assertThat(result).isNotNull();
+        assertThat(result.name()).isEqualTo(testOption1.getName());
+        assertThat(result.quantity()).isEqualTo(testOption1.getQuantity());
+
+        verify(productService, times(1)).getProductById(productId);
+        verify(optionRepository, times(1))
+                .existsByNameAndProductId(validCreateRequest.name(), productId);
+        verify(optionRepository, times(1)).save(any(Option.class));
+    }
+
+    @Test
+    void 옵션_생성_실패_중복_옵션() {
+        var productId = 1L;
+        when(productService.getProductById(productId)).thenReturn(testProduct);
+        when(optionRepository.existsByNameAndProductId(validCreateRequest.name(), productId))
+                .thenReturn(true);
+
+        assertThatThrownBy(() -> optionService.createOption(productId, validCreateRequest))
+                .isInstanceOf(EntityAlreadyExistsException.class)
+                .hasMessage("이미 존재하는 옵션입니다.");
+
+        verify(optionRepository, never()).save(any(Option.class));
+    }
+
+    @Test
+    void 상품_옵션_조회_성공() {
+        var productId = 1L;
+        var options = List.of(testOption1, testOption2);
+
+        when(optionRepository.getOptionsByProductId(productId)).thenReturn(options);
+
+        var result = optionService.getProductOptions(productId);
+
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).name()).isEqualTo(testOption1.getName());
+        assertThat(result.get(1).name()).isEqualTo(testOption2.getName());
+
+        verify(productService, times(1)).validateProductExists(productId);
+        verify(optionRepository, times(1)).getOptionsByProductId(productId);
+    }
+
+    @Test
+    void 옵션_삭제_성공() {
+        var optionId = 1L;
+        when(testProduct.getId()).thenReturn(1L);
+        when(optionRepository.findById(optionId)).thenReturn(Optional.of(testOption1));
+        when(optionRepository.countByProductId(1L)).thenReturn(2L);
+
+        optionService.deleteOption(optionId);
+
+        verify(optionRepository, times(1)).findById(optionId);
+        verify(optionRepository, times(1)).countByProductId(1L);
+        verify(optionRepository, times(1)).deleteById(optionId);
+    }
+
+    @Test
+    void 옵션_삭제_실패_마지막_옵션() {
+        var optionId = 1L;
+        when(testProduct.getId()).thenReturn(1L);
+        when(optionRepository.findById(optionId)).thenReturn(Optional.of(testOption1));
+        when(optionRepository.countByProductId(1L)).thenReturn(1L);
+
+        assertThatThrownBy(() -> optionService.deleteOption(optionId))
+                .isInstanceOf(EntityNotFoundException.class)
+                .hasMessage("최소 하나의 옵션은 남아 있어야 합니다.");
+
+        verify(optionRepository, never()).deleteById(optionId);
+    }
+
+    @Test
+    void 옵션_삭제_실패_존재하지_않는_옵션() {
+        var optionId = 999L;
+        when(optionRepository.findById(optionId)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> optionService.deleteOption(optionId))
+                .isInstanceOf(EntityNotFoundException.class)
+                .hasMessage("옵션을 찾을 수 없습니다.");
+
+        verify(optionRepository, never()).deleteById(optionId);
+        verify(optionRepository, never()).countByProductId(1L);
+    }
+
+    @Test
+    void 옵션_수량_차감_성공() {
+        var optionId = 1L;
+        var quantity = 10;
+        when(optionRepository.findById(optionId)).thenReturn(Optional.of(testOption1));
+
+        optionService.subtractOptionQuantity(optionId, quantity);
+
+        verify(optionRepository, times(1)).findById(optionId);
+    }
+
+    @Test
+    void 옵션_수량_차감_실패_존재하지_않는_옵션() {
+        var optionId = 999L;
+        var quantity = 10;
+        when(optionRepository.findById(optionId)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> optionService.subtractOptionQuantity(optionId, quantity))
+                .isInstanceOf(EntityNotFoundException.class)
+                .hasMessage("옵션을 찾을 수 없습니다.");
+    }
+
+    @Test
+    void 옵션_수량_차감_실패_수량_부족() {
+        var optionId = 1L;
+        var quantity = 200;
+        when(optionRepository.findById(optionId)).thenReturn(Optional.of(testOption1));
+
+        assertThatThrownBy(() -> optionService.subtractOptionQuantity(optionId, quantity))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("최소 1개의 수량은 남아 있어야 합니다.");
+
+        verify(optionRepository, times(1)).findById(optionId);
+    }
+}


### PR DESCRIPTION
2단계 리뷰 내용 반영 및 3단계 구현 완료하였습니다!

1. [2단계] PageRequestDto를 통한 각종 정렬 관련 입력 검증 추가 / PageResponseDto에 담아 반환하도록 수정하였습니다

<img width="1214" height="1266" alt="image" src="https://github.com/user-attachments/assets/de79ce08-d0e7-4746-a8e0-4d10fa59763c" />|<img width="1302" height="1384" alt="image" src="https://github.com/user-attachments/assets/28e8a577-d3fb-4dfb-8955-10fc53f4a8ff" />
:--:|:--:
getProducts|getWishlist

2. [3단계] Product에 대한 Option(상품 옵션) 항목 추가하였습니다
 - Option 생성 `POST /api/product/{productId}/options`
 - Option 삭제 (Product에 대한 Option이 1개일 경우 삭제 불가 처리) `DELETE /api/product/{productId}/options/{optionId}`
 - Product별 Option 목록 조회 가능 `GET /api/product/{productId}/options`
 - `상품에는 항상 하나 이상의 옵션이 있어야 한다.`는 조건 만족 위해 Product 생성 시 상품명으로 기본 옵션 1개 자동 생성하도록 작성
 - OptionService 단위 테스트 작성
 
<img width="404" height="726" alt="image" src="https://github.com/user-attachments/assets/f041ccd5-7b0f-4121-80ac-ed28127bf2e3" />


<br>
 감사합니다!


